### PR TITLE
feat: `repositories` endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,13 @@ https://github.com/artipie/front/LICENSE.txt
       <groupId>wtf.g4s8</groupId>
       <artifactId>matchers-json</artifactId>
       <version>1.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.api;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+/**
+ * Handle `GET` request to obtain repositories list.
+ * @since 0.1
+ */
+public final class Repositories implements Route {
+
+    /**
+     * Artipie repositories settings storage.
+     */
+    private final BlockingStorage storage;
+
+    /**
+     * Ctor.
+     * @param storage Artipie repositories settings storage
+     */
+    public Repositories(final BlockingStorage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public String handle(final Request request, final Response response) {
+        JsonArrayBuilder json = Json.createArrayBuilder();
+        for (final Key key : this.storage.list(Key.ROOT)) {
+            final String name = key.string();
+            if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+                json = json.add(
+                    Json.createObjectBuilder()
+                        .add("fullName", name.replaceAll("\\.yaml|\\.yml", "")).build()
+                );
+            }
+        }
+        // @checkstyle MagicNumberCheck (1 line)
+        response.status(200);
+        response.type("application/json");
+        return json.build().toString();
+    }
+}

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -43,8 +43,6 @@ public final class Repositories implements Route {
                 );
             }
         }
-        // @checkstyle MagicNumberCheck (1 line)
-        response.status(200);
         response.type("application/json");
         return json.build().toString();
     }

--- a/src/test/java/com/artipie/front/api/ApiAuthFilterTest.java
+++ b/src/test/java/com/artipie/front/api/ApiAuthFilterTest.java
@@ -7,7 +7,6 @@ package com.artipie.front.api;
 import com.artipie.front.api.ApiAuthFilter.ValidationException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/artipie/front/api/ApiAuthFilterTest.java
+++ b/src/test/java/com/artipie/front/api/ApiAuthFilterTest.java
@@ -6,6 +6,8 @@ package com.artipie.front.api;
 
 import com.artipie.front.api.ApiAuthFilter.ValidationException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -45,7 +47,7 @@ final class ApiAuthFilterTest {
         final var err = Assertions.assertThrows(
             HaltException.class,
             () -> new ApiAuthFilter(
-                new FakeTokenValidator(token, "any", Instant.now())
+                new FakeTokenValidator(token, "any", Instant.now().minus(1, ChronoUnit.DAYS))
             ).handle(req, rsp)
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/front/api/RepositoriesTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.api;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
+import spark.Request;
+import spark.Response;
+
+/**
+ * Test for {@link Repositories}.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RepositoriesTest {
+
+    @Test
+    void listsRepositories() throws JSONException {
+        final BlockingStorage blsto = new BlockingStorage(new InMemoryStorage());
+        blsto.save(new Key.From("Jane", "maven.yaml"), new byte[]{});
+        blsto.save(new Key.From("Jane", "python.yaml"), new byte[]{});
+        blsto.save(new Key.From("Jane", "binary.yaml"), new byte[]{});
+        blsto.save(new Key.From("John", "anaconda.yml"), new byte[]{});
+        blsto.save(new Key.From("John", "maven.yml"), new byte[]{});
+        blsto.save(new Key.From("rpm.yml"), new byte[]{});
+        final var resp = Mockito.mock(Response.class);
+        JSONAssert.assertEquals(
+            new Repositories(blsto).handle(Mockito.mock(Request.class), resp),
+            String.join(
+                "\n", "[",
+                "{\"fullName\":\"Jane/binary\"},",
+                "{\"fullName\":\"Jane/maven\"},",
+                "{\"fullName\":\"Jane/python\"},",
+                "{\"fullName\":\"John/anaconda\"},",
+                "{\"fullName\":\"John/maven\"},",
+                "{\"fullName\":\"rpm\"}",
+                "]"
+            ),
+            true
+        );
+        // @checkstyle MagicNumberCheck (1 line)
+        Mockito.verify(resp).status(200);
+        Mockito.verify(resp).type("application/json");
+    }
+
+}

--- a/src/test/java/com/artipie/front/api/RepositoriesTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesTest.java
@@ -45,8 +45,6 @@ class RepositoriesTest {
             ),
             true
         );
-        // @checkstyle MagicNumberCheck (1 line)
-        Mockito.verify(resp).status(200);
         Mockito.verify(resp).type("application/json");
     }
 


### PR DESCRIPTION
Part of #5 
Added `repositories` endpoint and corresponding test. Repositories list filtering according to user's permission will be implemented later, as soon we design the permissions