### PR TITLE
fieat(auth): web authentication and signin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ USER 2021:2020
 
 COPY target/dependency  /usr/lib/web-service/lib
 COPY target/${JAR_FILE} /usr/lib/web-service/app.jar
+COPY _config.yml /etc/artipie/artipie.yml
 
 WORKDIR /var/web-service
 HEALTHCHECK --interval=10s --timeout=3s \
@@ -28,5 +29,6 @@ CMD [ \
   "--add-opens", "java.base/java.security=ALL-UNNAMED", \
   "-cp", "/usr/lib/web-service/app.jar:/usr/lib/web-service/lib/*", \
   "com.artipie.front.Service", \
-  "--port=8080" \
+  "--port=8080", \
+  "--config=/etc/artipie/artipie.yml" \
 ]

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,9 @@
+# Default config for Artipie docker image
+meta:
+  storage:
+    type: fs
+    path: /var/artipie/repo
+  credentials:
+    type: file
+    path: _credentials.yml
+  layout: org

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@ https://github.com/artipie/front/LICENSE.txt
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.sparkjava</groupId>
+      <artifactId>spark-template-handlebars</artifactId>
+      <version>2.7.1</version>
+    </dependency>
+    <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
     </dependency>

--- a/src/main/java/com/artipie/front/AuthFilters.java
+++ b/src/main/java/com/artipie/front/AuthFilters.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front;
+
+import java.util.Map;
+import org.eclipse.jetty.http.HttpStatus;
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+/**
+ * Auth Spark filters.
+ * @since 1.0
+ * @checkstyle IndentationCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public enum AuthFilters implements Filter {
+    /**
+     * Authenticate user if session is not valid.
+     */
+    AUTHENTICATE(
+        (req, rsp) -> {
+            if (req.pathInfo().equals("/signin")) {
+                return;
+            }
+            if (req.session() == null || !req.session().attributes().contains("uid")) {
+                rsp.redirect("/signin");
+                Spark.halt(HttpStatus.UNAUTHORIZED_401);
+            }
+        }
+    ),
+
+    /**
+     * Add session attributes.
+     */
+    SESSION_ATTRS(
+        (req, rsp) -> {
+            final var attrs = Map.of(
+                "uid", RequestAttr.Standard.USER_ID
+            );
+            if (req.session() == null) {
+                attrs.values().forEach(attr -> attr.remove(req));
+            }
+            attrs.forEach(
+                (name, attr) -> {
+                    if (req.session().attributes().contains(name)) {
+                        attr.write(req, req.session().attribute(name));
+                    } else {
+                        attr.remove(req);
+                    }
+                }
+            );
+        }
+    );
+
+    /**
+     * Filter function.
+     */
+    private final Filter func;
+
+    /**
+     * Private enum ctor.
+     * @param func Filter function
+     */
+    AuthFilters(final Filter func) {
+        this.func = func;
+    }
+
+    @Override
+    public void handle(final Request req, final Response rsp) throws Exception {
+        if (!req.pathInfo().startsWith("/api")) {
+            this.func.handle(req, rsp);
+        }
+    }
+}

--- a/src/main/java/com/artipie/front/RequestAttr.java
+++ b/src/main/java/com/artipie/front/RequestAttr.java
@@ -29,6 +29,12 @@ public interface RequestAttr<T> {
     void write(Request req, T val);
 
     /**
+     * Remove attribute.
+     * @param req Spark request
+     */
+    void remove(Request req);
+
+    /**
      * Standard attributes.
      * @since 1.0
      */
@@ -59,6 +65,11 @@ public interface RequestAttr<T> {
         @Override
         public void write(final Request req, final String val) {
             req.attribute(this.name, val);
+        }
+
+        @Override
+        public void remove(final Request req) {
+            req.raw().removeAttribute(this.name);
         }
     }
 }

--- a/src/main/java/com/artipie/front/misc/RouteWrap.java
+++ b/src/main/java/com/artipie/front/misc/RouteWrap.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.misc;
+
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+/**
+ * Decorator for Spark route.
+ * @since 1.0
+ */
+public abstract class RouteWrap implements Route {
+
+    /**
+     * Origin route.
+     */
+    private final Route origin;
+
+    /**
+     * Wrap origin route.
+     * @param origin Route
+     */
+    protected RouteWrap(final Route origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public final Object handle(final Request req, final Response rsp) throws Exception {
+        return this.origin.handle(req, rsp);
+    }
+}

--- a/src/main/java/com/artipie/front/misc/package-info.java
+++ b/src/main/java/com/artipie/front/misc/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+
+/**
+ * Helper objects.
+ * @since 1.0
+ */
+package com.artipie.front.misc;

--- a/src/main/java/com/artipie/front/ui/HbPage.java
+++ b/src/main/java/com/artipie/front/ui/HbPage.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.ui;
+
+import java.util.Map;
+import java.util.function.Function;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+import spark.template.handlebars.HandlebarsTemplateEngine;
+
+/**
+ * Handlebars page.
+ * @since 1.0
+ */
+final class HbPage implements Route {
+
+    /**
+     * Template engine.
+     */
+    private static final HandlebarsTemplateEngine ENGINE = new HandlebarsTemplateEngine("/html");
+
+    /**
+     * Template name.
+     */
+    private final String template;
+
+    /**
+     * Template params.
+     */
+    private final Function<? super Request, ? extends Map<String, ? extends Object>> params;
+
+    /**
+     * New page.
+     * @param template Template name
+     * @param params Params
+     */
+    HbPage(final String template, final Map<String, ? extends Object> params) {
+        this(template, req -> params);
+    }
+
+    /**
+     * New page.
+     * @param template Template name
+     * @param params Create params from request
+     */
+    HbPage(final String template,
+        final Function<? super Request, ? extends Map<String, ? extends Object>> params) {
+        this.template = template;
+        this.params = params;
+    }
+
+    @Override
+    public Object handle(final Request req, final Response rsp) throws Exception {
+        rsp.type("text/html");
+        return HbPage.ENGINE.render(new ModelAndView(this.params.apply(req), this.template));
+    }
+}

--- a/src/main/java/com/artipie/front/ui/PostSignIn.java
+++ b/src/main/java/com/artipie/front/ui/PostSignIn.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.ui;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.eclipse.jetty.http.HttpStatus;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+import spark.Spark;
+
+/**
+ * Signin form POST handler.
+ * @since 1.0
+ * @checkstyle AvoidDuplicateLiterals (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class PostSignIn implements Route {
+
+    /**
+     * Password authenticator.
+     */
+    private final PasswordAuthenticator auth;
+
+    /**
+     * New signin form processor.
+     * @param auth Password auth
+     */
+    public PostSignIn(final PasswordAuthenticator auth) {
+        this.auth = auth;
+    }
+
+    @Override
+    public Object handle(final Request req, final Response rsp) throws Exception {
+        if (req.session() == null) {
+            Spark.halt(HttpStatus.BAD_REQUEST_400, "session is empty");
+        }
+        final String crsf = req.session().attribute("crsf");
+        req.session().removeAttribute("crsf");
+        final var valid = Objects.equals(
+            req.queryParamOrDefault("_crsf", ""), crsf
+        );
+        if (!valid) {
+            Spark.halt(HttpStatus.BAD_REQUEST_400, "CRSF validation failed");
+        }
+        final var uid = this.auth.authenticate(
+            req.queryParamOrDefault("username", ""),
+            req.queryParamOrDefault("password", "")
+        );
+        uid.ifPresentOrElse(
+            val -> req.session().attribute("uid", val),
+            () -> Spark.halt(HttpStatus.UNAUTHORIZED_401, "bad credentials")
+        );
+        return "OK";
+    }
+
+    /**
+     * User name authentication function.
+     * @since 1.0
+     */
+    @FunctionalInterface
+    public interface PasswordAuthenticator {
+
+        /**
+         * Authenticate user by password.
+         * @param user Login
+         * @param password Password
+         * @return User ID if found
+         */
+        Optional<String> authenticate(String user, String password);
+    }
+}

--- a/src/main/java/com/artipie/front/ui/SignInPage.java
+++ b/src/main/java/com/artipie/front/ui/SignInPage.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.ui;
+
+import com.artipie.front.misc.RouteWrap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Sign in page.
+ * @since 1.0
+ * @checkstyle AvoidDuplicateLiterals (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class SignInPage extends RouteWrap {
+
+    /**
+     * New sign-in page.
+     */
+    public SignInPage() {
+        super(
+            new HbPage(
+                "signin",
+                req -> {
+                    final var crsf = Optional.<String>ofNullable(
+                        req.session(true).attribute("crsf")
+                    ).orElseGet(() -> UUID.randomUUID().toString());
+                    req.session(true).attribute("crsf", crsf);
+                    return Map.of("title", "Sign in", "crsf", crsf);
+                }
+            )
+        );
+    }
+}

--- a/src/main/java/com/artipie/front/ui/package-info.java
+++ b/src/main/java/com/artipie/front/ui/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+
+/**
+ * User interface routes.
+ * @since 1.0
+ */
+package com.artipie.front.ui;

--- a/src/main/resources/html/base
+++ b/src/main/resources/html/base
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{{title}}</title>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="shortcut icon" href="/logo.png"/>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css"/>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/yegor256/drops@gh-pages/drops.min.css"/>
+  </head>
+  <body>
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <a href="/"><img src="https://www.artipie.com/logo.svg" style="height:92px;" alt="logo"/></a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+    <section>
+      <article>
+        {{#block "content"}}
+        {{/block}}
+      </article>
+    </section>
+    <footer>
+      <nav>
+        <ul>
+          <li>
+            &copy; Made by <a href="https://www.artipie.com">Artipie</a>
+          </li>
+        </ul>
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/src/main/resources/html/signin
+++ b/src/main/resources/html/signin
@@ -1,0 +1,15 @@
+{{#partial "content"}}
+
+<form id="form-signin" method="post">
+    <fieldset>
+        <label for="username">User:</label>
+        <input name="username" type="text" placeholder="john123"/>
+        <label for="password">Password:</label>
+        <input name="password" type="password"/>
+        <input name="_crsf" type="hidden" value="{{crsf}}"/>
+        <br/>
+        <input name="submit" type="submit"/>
+    </fieldset>
+</form>
+{{/partial}}
+{{> base}}


### PR DESCRIPTION
Add `/signin` page to authenticate
by username and password with CRSF token.
Create user session, add filters to redirect on
unauthorized access and bind user-id request attributes.

Ticket: #4