### PR TITLE
feat(auth): add credentials from yaml

### DIFF
--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -10,6 +10,7 @@ import com.artipie.front.api.GetRepository;
 import com.artipie.front.api.HeadRepository;
 import com.artipie.front.api.NotFoundException;
 import com.artipie.front.api.Repositories;
+import com.artipie.front.auth.AuthByPassword;
 import com.artipie.front.internal.HealthRoute;
 import com.artipie.front.misc.RepoSettings;
 import com.artipie.front.settings.ArtipieYaml;
@@ -18,7 +19,6 @@ import com.artipie.front.ui.SignInPage;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 import javax.json.Json;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -147,8 +147,7 @@ public final class Service {
                 this.ignite.post(
                     "",
                     new PostSignIn(
-                        (user, pass) -> Optional.of(user)
-                            .filter(u -> u.equals("admin") && pass.equals("qwerty"))
+                        AuthByPassword.withCredentials(this.settings.credentials())
                     )
                 );
             }

--- a/src/main/java/com/artipie/front/auth/AuthByPassword.java
+++ b/src/main/java/com/artipie/front/auth/AuthByPassword.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import java.util.Optional;
+
+/**
+ * By password authentication.
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface AuthByPassword {
+
+    /**
+     * Authenticate user by password.
+     * @param user Login
+     * @param password Password
+     * @return User ID if found
+     */
+    Optional<String> authenticate(String user, String password);
+
+    /**
+     * Authenticator with credentials.
+     * @param cred Credentials
+     * @return Authentication function
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    static AuthByPassword withCredentials(final Credentials cred) {
+        return (name, pass) -> cred.user(name)
+            .filter(user -> user.validatePassword(pass))
+            .map(ignore -> name);
+    }
+}

--- a/src/main/java/com/artipie/front/auth/Credentials.java
+++ b/src/main/java/com/artipie/front/auth/Credentials.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Credentials.
+ * @since 1.0
+ */
+public interface Credentials {
+    /**
+     * Find user by name.
+     * @param name Username
+     * @return User if found
+     */
+    Optional<User> user(String name);
+
+    /**
+     * User.
+     * @since 1.0
+     */
+    interface User {
+
+        /**
+         * Validate user password.
+         * @param pass Password to check
+         * @return True if password is valid
+         */
+        boolean validatePassword(String pass);
+
+        /**
+         * User groups.
+         * @return Readonly set of groups
+         */
+        Set<? extends String> groups();
+    }
+}

--- a/src/main/java/com/artipie/front/auth/package-info.java
+++ b/src/main/java/com/artipie/front/auth/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+
+/**
+ * AUthentication and authorization.
+ * @since 1.0
+ */
+package com.artipie.front.auth;

--- a/src/main/java/com/artipie/front/settings/ArtipieYaml.java
+++ b/src/main/java/com/artipie/front/settings/ArtipieYaml.java
@@ -4,17 +4,24 @@
  */
 package com.artipie.front.settings;
 
+import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.ArtipieException;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.SubStorage;
 import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.front.auth.Credentials;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Artipie yaml settings.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class ArtipieYaml {
 
@@ -65,6 +72,29 @@ public final class ArtipieYaml {
             .<Storage>map(str -> new SubStorage(new Key.From(str), this.asto()))
             .orElse(this.asto())
         );
+    }
+
+    /**
+     * Credentials from config.
+     * @return Credentials
+     */
+    public Credentials credentials() {
+        final var cred = this.content.yamlMapping("credentials");
+        if (!cred.string("type").equals("file")) {
+            throw new NotImplementedException("not implemented yet");
+        }
+        try {
+            return new YamlCredentials(
+                Yaml.createYamlInput(
+                    new String(
+                        this.storage().value(new Key.From(cred.string("path"))),
+                        StandardCharsets.UTF_8
+                    )
+                ).readYamlMapping()
+            );
+        } catch (final IOException iex) {
+            throw new UncheckedIOException(iex);
+        }
     }
 
     @Override

--- a/src/main/java/com/artipie/front/settings/YamlCredentials.java
+++ b/src/main/java/com/artipie/front/settings/YamlCredentials.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.settings;
+
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.front.auth.Credentials;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * Yaml credentials parser.
+ * @since 1.0
+ */
+public final class YamlCredentials implements Credentials {
+
+    /**
+     * Yaml source.
+     */
+    private final YamlMapping mapping;
+
+    /**
+     * New yaml credentials.
+     * @param mapping Yaml
+     */
+    public YamlCredentials(final YamlMapping mapping) {
+        this.mapping = mapping;
+    }
+
+    @Override
+    public Optional<Credentials.User> user(final String name) {
+        return Optional.ofNullable(this.mapping.yamlMapping("credentials"))
+            .flatMap(cred -> Optional.ofNullable(cred.yamlMapping(name)))
+            .map(User::new);
+    }
+
+    /**
+     * Yaml user item.
+     * @since 1.0
+     */
+    private static final class User implements Credentials.User {
+
+        /**
+         * Yaml source.
+         */
+        private final YamlMapping mapping;
+
+        /**
+         * New user.
+         * @param mapping Yaml
+         */
+        private User(final YamlMapping mapping) {
+            this.mapping = mapping;
+        }
+
+        @Override
+        public boolean validatePassword(final String pass) {
+            final var config = this.mapping.string("pass");
+            if (config == null) {
+                throw new IllegalStateException(
+                    "invalid credentials configuration: `pass` field not found"
+                );
+            }
+            final var type = this.mapping.string("type");
+            final boolean res;
+            if (type == null) {
+                res = validateStringPass(config, pass);
+            } else {
+                res = validateStringPass(String.join(":", type, config), pass);
+            }
+            return res;
+        }
+
+        @Override
+        public Set<? extends String> groups() {
+            return Optional.ofNullable(this.mapping.yamlSequence("groups"))
+                .map(seq -> StreamSupport.stream(seq.spliterator(), false))
+                .orElse(Stream.empty())
+                .map(node -> node.asScalar().value())
+                .collect(Collectors.toSet());
+        }
+
+        /**
+         * Validate password string.
+         * @param config Passowrd string config
+         * @param pass Actual password
+         * @return True if password is valid
+         * @checkstyle ReturnCountCheck (30 lines)
+         */
+        @SuppressWarnings("PMD.OnlyOneReturn")
+        private static boolean validateStringPass(final String config, final String pass) {
+            final var parts = config.split(":");
+            switch (parts[0]) {
+                case "plain":
+                    return Objects.equals(parts[1], pass);
+                case "sha256":
+                    return Objects.equals(parts[1], DigestUtils.sha256Hex(pass));
+                default:
+                    throw new IllegalStateException(
+                        String.format(
+                            "invalid credentials configuration: `pass` type `%s` is not supported",
+                                parts[0]
+                        )
+                    );
+            }
+        }
+    }
+}

--- a/src/main/java/com/artipie/front/ui/PostSignIn.java
+++ b/src/main/java/com/artipie/front/ui/PostSignIn.java
@@ -4,8 +4,8 @@
  */
 package com.artipie.front.ui;
 
+import com.artipie.front.auth.AuthByPassword;
 import java.util.Objects;
-import java.util.Optional;
 import org.eclipse.jetty.http.HttpStatus;
 import spark.Request;
 import spark.Response;
@@ -23,13 +23,13 @@ public final class PostSignIn implements Route {
     /**
      * Password authenticator.
      */
-    private final PasswordAuthenticator auth;
+    private final AuthByPassword auth;
 
     /**
      * New signin form processor.
      * @param auth Password auth
      */
-    public PostSignIn(final PasswordAuthenticator auth) {
+    public PostSignIn(final AuthByPassword auth) {
         this.auth = auth;
     }
 
@@ -55,21 +55,5 @@ public final class PostSignIn implements Route {
             () -> Spark.halt(HttpStatus.UNAUTHORIZED_401, "bad credentials")
         );
         return "OK";
-    }
-
-    /**
-     * User name authentication function.
-     * @since 1.0
-     */
-    @FunctionalInterface
-    public interface PasswordAuthenticator {
-
-        /**
-         * Authenticate user by password.
-         * @param user Login
-         * @param password Password
-         * @return User ID if found
-         */
-        Optional<String> authenticate(String user, String password);
     }
 }

--- a/src/test/java/com/artipie/front/settings/YamlCredentialsTest.java
+++ b/src/test/java/com/artipie/front/settings/YamlCredentialsTest.java
@@ -1,0 +1,192 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.settings;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link YamlCredentials}.
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class YamlCredentialsTest {
+
+    @Test
+    void findUser() {
+        final var username = "John";
+        final var user = new YamlCredentials(
+            credYaml(PasswordFormat.SIMPLE, new User(username, "plain", "qwerty"))
+        ).user(username);
+        MatcherAssert.assertThat(
+            user.isPresent(), Matchers.is(true)
+        );
+    }
+
+    @Test
+    void validateShaPass() {
+        final var username = "Alice";
+        final var user = new YamlCredentials(
+            // @checkstyle LineLengthCheck (1 line)
+            credYaml(PasswordFormat.SIMPLE, new User(username, "sha256", "65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5"))
+        ).user(username);
+        MatcherAssert.assertThat(
+            user.orElseThrow().validatePassword("qwerty"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void validatePlainPass() {
+        final var username = "Bob";
+        final var user = new YamlCredentials(
+            credYaml(PasswordFormat.SIMPLE, new User(username, "plain", "1234"))
+        ).user(username);
+        MatcherAssert.assertThat(
+            user.orElseThrow().validatePassword("1234"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void validateStrucPass() {
+        final var username = "John";
+        final var type = "plain";
+        final var pass = "zxcvb";
+        final var user = new YamlCredentials(
+            credYaml(PasswordFormat.STRUCT, new User(username, type, pass))
+        ).user(username).get();
+        MatcherAssert.assertThat(
+            user.validatePassword(pass),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void readUserGroups() {
+        final var username = "Jane";
+        final var admins = "admins";
+        final var readers = "readers";
+        final var groups = new YamlCredentials(
+            credYaml(PasswordFormat.SIMPLE, new User(username, "plain", "qwerty", admins, readers))
+        ).user(username).orElseThrow().groups();
+        MatcherAssert.assertThat(
+            groups,
+            Matchers.containsInAnyOrder(admins, readers)
+        );
+    }
+
+    /**
+     * Credentials YAML.
+     * @param fmt Password format
+     * @param users User list
+     * @return Yaml
+     */
+    private static YamlMapping credYaml(final PasswordFormat fmt, final User... users) {
+        var builder = Yaml.createYamlMappingBuilder();
+        for (final var user : users) {
+            builder = user.render(builder, fmt);
+        }
+        return Yaml.createYamlMappingBuilder().add("credentials", builder.build()).build();
+    }
+
+    /**
+     * User in yaml.
+     * @since 1.0
+     */
+    private static final class User {
+
+        /**
+         * User name.
+         */
+        private final String name;
+
+        /**
+         * User password type.
+         */
+        private final String ptype;
+
+        /**
+         * User password.
+         */
+        private final String pass;
+
+        /**
+         * User groups.
+         */
+        private final Set<String> groups;
+
+        /**
+         * New user.
+         * @param name User name
+         * @param ptype User password type
+         * @param pass User password
+         * @param groups User groups
+         * @checkstyle ParameterNumberCheck (10 lines)
+         */
+        User(final String name, final String ptype, final String pass,
+            final String... groups) {
+            this.name = name;
+            this.ptype = ptype;
+            this.pass = pass;
+            this.groups = new HashSet<>(Arrays.asList(groups));
+        }
+
+        /**
+         * Render user to a yaml.
+         * @param builder Yaml builder
+         * @param fmt Password format
+         * @return Yaml builder
+         */
+        YamlMappingBuilder render(final YamlMappingBuilder builder, final PasswordFormat fmt) {
+            var yaml = Yaml.createYamlMappingBuilder();
+            yaml = fmt.apply(yaml, this.ptype, this.pass);
+            if (!this.groups.isEmpty()) {
+                var gbuild = Yaml.createYamlSequenceBuilder();
+                for (final var group : this.groups) {
+                    gbuild = gbuild.add(group);
+                }
+                yaml = yaml.add("groups", gbuild.build());
+            }
+            return builder.add(this.name, yaml.build());
+        }
+    }
+
+    /**
+     * Format of user password.
+     * @since 1.0
+     */
+    @FunctionalInterface
+    private interface PasswordFormat {
+
+        /**
+         * Simple format, like {@code plain:qwerty}.
+         */
+        PasswordFormat SIMPLE =
+            (builder, type, pass) -> builder.add("pass", String.format("%s:%s", type, pass));
+
+        /**
+         * Structured format, like {@code {type: plain, pass: qwerty}}.
+         */
+        PasswordFormat STRUCT =
+            (builder, type, pass) -> builder.add("type", type).add("pass", pass);
+
+        /**
+         * Apply format using builder.
+         * @param builder Yaml builder
+         * @param type Password type
+         * @param pass Password value
+         * @return Builder
+         */
+        YamlMappingBuilder apply(YamlMappingBuilder builder, String type, String pass);
+    }
+}


### PR DESCRIPTION
Add `Credentials` interface to validate user passord
and read groups. Move `AuthByPassword` from nested class to
`auth` pacakge, create function to build from credentials.
Add test for yaml credentials.

Ticket: #4