### PR TITLE
refactor: add classes for params and req path

### DIFF
--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -19,6 +19,7 @@ import com.artipie.front.api.Repositories;
 import com.artipie.front.api.Users;
 import com.artipie.front.auth.AuthByPassword;
 import com.artipie.front.internal.HealthRoute;
+import com.artipie.front.misc.RequestPath;
 import com.artipie.front.settings.ArtipieYaml;
 import com.artipie.front.settings.RepoSettings;
 import com.artipie.front.ui.PostSignIn;
@@ -134,16 +135,18 @@ public final class Service {
                         final RepoSettings stn = new RepoSettings(
                             this.settings.layout(), this.settings.repoConfigsStorage()
                         );
-                        final String repo = String.format("/%s", GetRepository.PARAM);
+                        final RequestPath path = new RequestPath().with(GetRepository.NAME_PARAM);
                         this.ignite.get(
-                            repo, MimeTypes.Type.APPLICATION_JSON.asString(),
+                            path.toString(), MimeTypes.Type.APPLICATION_JSON.asString(),
                             new GetRepository(stn)
                         );
-                        this.ignite.head(repo, new HeadRepository(stn));
-                        this.ignite.delete(repo, new DeleteRepository(stn));
-                        this.ignite.put(repo, new PutRepository(stn));
-                        final String perms = String.format("/%s/permissions", GetRepository.PARAM);
-                        this.ignite.get(perms, new GetRepositoryPermissions(stn));
+                        this.ignite.head(path.toString(), new HeadRepository(stn));
+                        this.ignite.delete(path.toString(), new DeleteRepository(stn));
+                        this.ignite.put(path.toString(), new PutRepository(stn));
+                        this.ignite.get(
+                            path.with("permissions").toString(),
+                            new GetRepositoryPermissions(stn)
+                        );
                     }
                 );
                 this.ignite.path(
@@ -152,10 +155,10 @@ public final class Service {
                             "/", MimeTypes.Type.APPLICATION_JSON.asString(),
                             new Users(this.settings.users())
                         );
-                        final String usr = String.format("/%s", GetUser.USER_PARAM);
-                        this.ignite.get(usr, new GetUser(this.settings.credentials()));
-                        this.ignite.put(usr, new PutUser(this.settings.users()));
-                        this.ignite.head(usr, new HeadUser(this.settings.credentials()));
+                        final String path = new RequestPath().with(GetUser.USER_PARAM).toString();
+                        this.ignite.get(path, new GetUser(this.settings.credentials()));
+                        this.ignite.put(path, new PutUser(this.settings.users()));
+                        this.ignite.head(path, new HeadUser(this.settings.credentials()));
                     }
                 );
             }

--- a/src/main/java/com/artipie/front/api/DeleteRepository.java
+++ b/src/main/java/com/artipie/front/api/DeleteRepository.java
@@ -32,7 +32,7 @@ public final class DeleteRepository implements Route {
     @Override
     public Object handle(final Request request, final Response response) {
         this.stn.delete(
-            request.params(GetRepository.PARAM),
+            GetRepository.NAME_PARAM.parse(request),
             RequestAttr.Standard.USER_ID.readOrThrow(request)
         );
         return null;

--- a/src/main/java/com/artipie/front/api/GetRepository.java
+++ b/src/main/java/com/artipie/front/api/GetRepository.java
@@ -5,6 +5,7 @@
 package com.artipie.front.api;
 
 import com.artipie.front.RequestAttr;
+import com.artipie.front.misc.RequestPath;
 import com.artipie.front.misc.Yaml2Json;
 import com.artipie.front.settings.RepoSettings;
 import java.nio.charset.StandardCharsets;
@@ -26,7 +27,7 @@ public final class GetRepository implements Route {
     /**
      * Repository name request parameter.
      */
-    public static final String PARAM = ":name";
+    public static final RequestPath.Param NAME_PARAM = new RequestPath.Param("name");
 
     /**
      * Repository settings yaml secton `repo` name.
@@ -51,7 +52,7 @@ public final class GetRepository implements Route {
         final JsonObject repo = new Yaml2Json().apply(
             new String(
                 this.stn.value(
-                    request.params(GetRepository.PARAM),
+                    GetRepository.NAME_PARAM.parse(request),
                     RequestAttr.Standard.USER_ID.readOrThrow(request)
                 ),
                 StandardCharsets.UTF_8

--- a/src/main/java/com/artipie/front/api/GetRepositoryPermissions.java
+++ b/src/main/java/com/artipie/front/api/GetRepositoryPermissions.java
@@ -44,7 +44,7 @@ public final class GetRepositoryPermissions implements Route {
         final JsonObject perms = new Yaml2Json().apply(
             new String(
                 this.stn.value(
-                    request.params(GetRepository.PARAM),
+                    GetRepository.NAME_PARAM.parse(request),
                     RequestAttr.Standard.USER_ID.readOrThrow(request)
                 ),
                 StandardCharsets.UTF_8

--- a/src/main/java/com/artipie/front/api/GetUser.java
+++ b/src/main/java/com/artipie/front/api/GetUser.java
@@ -6,6 +6,7 @@ package com.artipie.front.api;
 
 import com.artipie.front.auth.Credentials;
 import com.artipie.front.auth.User;
+import com.artipie.front.misc.RequestPath;
 import java.util.Optional;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -21,11 +22,10 @@ import spark.Route;
  * @checkstyle ReturnCountCheck (500 lines)
  */
 public final class GetUser implements Route {
-
     /**
-     * User parameter name.
+     * User parameter.
      */
-    public static final String USER_PARAM = ":user";
+    public static final RequestPath.Param USER_PARAM = new RequestPath.Param("user");
 
     /**
      * Credentials.
@@ -43,7 +43,7 @@ public final class GetUser implements Route {
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
     public String handle(final Request request, final Response response) {
-        final String name = request.params(GetUser.USER_PARAM);
+        final String name = GetUser.USER_PARAM.parse(request);
         final Optional<User> user = this.creds.user(name);
         if (user.isPresent()) {
             final JsonObjectBuilder json = Json.createObjectBuilder();

--- a/src/main/java/com/artipie/front/api/HeadRepository.java
+++ b/src/main/java/com/artipie/front/api/HeadRepository.java
@@ -32,7 +32,7 @@ public final class HeadRepository implements Route {
     @Override
     public Object handle(final Request request, final Response response) {
         this.stn.key(
-            request.params(GetRepository.PARAM),
+            GetRepository.NAME_PARAM.parse(request),
             RequestAttr.Standard.USER_ID.readOrThrow(request)
         );
         return null;

--- a/src/main/java/com/artipie/front/api/HeadUser.java
+++ b/src/main/java/com/artipie/front/api/HeadUser.java
@@ -31,7 +31,7 @@ public final class HeadUser implements Route {
 
     @Override
     public Object handle(final Request request, final Response response) {
-        if (this.creds.user(request.params(GetUser.USER_PARAM)).isEmpty()) {
+        if (this.creds.user(GetUser.USER_PARAM.parse(request)).isEmpty()) {
             response.status(HttpStatus.NOT_FOUND_404);
         } else {
             response.status(HttpStatus.OK_200);

--- a/src/main/java/com/artipie/front/api/PutRepository.java
+++ b/src/main/java/com/artipie/front/api/PutRepository.java
@@ -39,7 +39,7 @@ public final class PutRepository implements Route {
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
     public Object handle(final Request request, final Response response) {
-        final String param = request.params(GetRepository.PARAM);
+        final String param = GetRepository.NAME_PARAM.parse(request);
         final String uid = RequestAttr.Standard.USER_ID.readOrThrow(request);
         if (this.stn.exists(param, uid)) {
             response.status(HttpStatus.CONFLICT_409);

--- a/src/main/java/com/artipie/front/api/PutUser.java
+++ b/src/main/java/com/artipie/front/api/PutUser.java
@@ -36,7 +36,7 @@ public final class PutUser implements Route {
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
     public Object handle(final Request request, final Response response) {
-        final String name = request.params(GetUser.USER_PARAM);
+        final String name = GetUser.USER_PARAM.parse(request);
         if (this.users.list().stream().anyMatch(usr -> name.equals(usr.uid()))) {
             response.status(HttpStatus.CONFLICT_409);
             return String.format("User %s already exists", name);

--- a/src/main/java/com/artipie/front/misc/RequestPath.java
+++ b/src/main/java/com/artipie/front/misc/RequestPath.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.misc;
+
+import spark.Request;
+
+/**
+ * Request path for spark with params.
+ * @since 1.0
+ */
+public final class RequestPath {
+
+    /**
+     * Path route.
+     */
+    private final String path;
+
+    /**
+     * New empty path.
+     */
+    public RequestPath() {
+        this("");
+    }
+
+    /**
+     * New path.
+     * @param path With intial path
+     */
+    public RequestPath(final String path) {
+        this.path = path;
+    }
+
+    /**
+     * With param.
+     * @param param Path param
+     * @return New request path
+     */
+    public RequestPath with(final Param param) {
+        return new RequestPath(String.join("/", this.path, param.toString()));
+    }
+
+    /**
+     * With plain path part.
+     * @param part Path part
+     * @return New request path
+     */
+    public RequestPath with(final String part) {
+        return new RequestPath(String.join("/", this.path, part));
+    }
+
+    @Override
+    public String toString() {
+        final String res;
+        if (this.path.isEmpty()) {
+            res = "/";
+        } else {
+            res = this.path;
+        }
+        return res;
+    }
+
+    /**
+     * Path request param.
+     * @since 1.0
+     */
+    public static final class Param {
+
+        /**
+         * Param name.
+         */
+        private final String name;
+
+        /**
+         * New param.
+         * @param name With name
+         */
+        public Param(final String name) {
+            this.name = ":".concat(name);
+        }
+
+        /**
+         * Parse Spark request.
+         * @param req Request
+         * @return Param value
+         */
+        public String parse(final Request req) {
+            return req.params(this.name);
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+}

--- a/src/test/java/com/artipie/front/api/DeleteRepositoryTest.java
+++ b/src/test/java/com/artipie/front/api/DeleteRepositoryTest.java
@@ -44,7 +44,7 @@ class DeleteRepositoryTest {
         final String uid = "Alice";
         this.blsto.save(new Key.From(key), new byte[]{});
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(uid);
         MatcherAssert.assertThat(
             "Failed to process request",

--- a/src/test/java/com/artipie/front/api/GetRepositoryPermissionsTest.java
+++ b/src/test/java/com/artipie/front/api/GetRepositoryPermissionsTest.java
@@ -48,7 +48,7 @@ class GetRepositoryPermissionsTest {
             new TestResource("GetRepositoryPermissionsTest/my-maven.yaml").asBytes()
         );
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-maven");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-maven");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         JSONAssert.assertEquals(
             new GetRepositoryPermissions(this.snt).handle(rqs, Mockito.mock(Response.class)),
@@ -75,7 +75,7 @@ class GetRepositoryPermissionsTest {
             ).getBytes(StandardCharsets.UTF_8)
         );
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-python");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-python");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("alice");
         JSONAssert.assertEquals(
             new GetRepositoryPermissions(this.snt).handle(rqs, Mockito.mock(Response.class)),

--- a/src/test/java/com/artipie/front/api/GetRepositoryTest.java
+++ b/src/test/java/com/artipie/front/api/GetRepositoryTest.java
@@ -38,7 +38,7 @@ class GetRepositoryTest {
         );
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         JSONAssert.assertEquals(
             new GetRepository(new RepoSettings("flat", blsto)).handle(rqs, resp),

--- a/src/test/java/com/artipie/front/api/GetUserTest.java
+++ b/src/test/java/com/artipie/front/api/GetUserTest.java
@@ -32,7 +32,7 @@ class GetUserTest {
         }, delimiterString = ";")
     void returnsUserInfo(final String name, final String res) throws JSONException {
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn(name);
         JSONAssert.assertEquals(
             new GetUser(
                 new YamlCredentials(
@@ -53,7 +53,7 @@ class GetUserTest {
     @Test
     void returnNotFound() {
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn("any");
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn("any");
         final Response resp = Mockito.mock(Response.class);
         new GetUser(
             new YamlCredentials(

--- a/src/test/java/com/artipie/front/api/HeadRepositoryTest.java
+++ b/src/test/java/com/artipie/front/api/HeadRepositoryTest.java
@@ -45,7 +45,7 @@ class HeadRepositoryTest {
         final String uid = "Mark";
         this.blsto.save(new Key.From(key), new byte[]{});
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(uid);
         MatcherAssert.assertThat(
             new HeadRepository(new RepoSettings(layout, this.blsto))
@@ -57,7 +57,7 @@ class HeadRepositoryTest {
     @Test
     void throwsExceptionWhenNotFound() {
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-repo");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-repo");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Assertions.assertThrows(
             NotFoundException.class,

--- a/src/test/java/com/artipie/front/api/HeadUserTest.java
+++ b/src/test/java/com/artipie/front/api/HeadUserTest.java
@@ -23,7 +23,7 @@ class HeadUserTest {
     void returnsOkWhenUserFound() {
         final var rqs = Mockito.mock(Request.class);
         final String uid = "Alice";
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn(uid);
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn(uid);
         final Response resp = Mockito.mock(Response.class);
         new HeadUser(
             new YamlCredentials(
@@ -39,7 +39,7 @@ class HeadUserTest {
     @Test
     void returnsNotFoundWhenUserDoesNotExists() {
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn("Someone");
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn("Someone");
         final Response resp = Mockito.mock(Response.class);
         new HeadUser(
             new YamlCredentials(

--- a/src/test/java/com/artipie/front/api/PutRepositoryTest.java
+++ b/src/test/java/com/artipie/front/api/PutRepositoryTest.java
@@ -45,7 +45,7 @@ class PutRepositoryTest {
     void addsNewRepo() {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-rpm");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-rpm");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Mockito.when(rqs.body()).thenReturn(
             new String(
@@ -88,7 +88,7 @@ class PutRepositoryTest {
     void returnsBadRequestWhenReqIsInvalid(final String body) {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-maven");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-maven");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Mockito.when(rqs.body()).thenReturn(body);
         new PutRepository(new RepoSettings("org", this.blsto)).handle(rqs, resp);
@@ -101,7 +101,7 @@ class PutRepositoryTest {
         this.blsto.save(new Key.From(jane, "my-docker.yml"), new byte[]{});
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetRepository.PARAM)).thenReturn("my-docker");
+        Mockito.when(rqs.params(GetRepository.NAME_PARAM.toString())).thenReturn("my-docker");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(jane);
         new PutRepository(new RepoSettings("org", this.blsto)).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CONFLICT_409);

--- a/src/test/java/com/artipie/front/api/PutUserTest.java
+++ b/src/test/java/com/artipie/front/api/PutUserTest.java
@@ -64,7 +64,7 @@ class PutUserTest {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         final var name = "john";
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.body()).thenReturn(this.rqBody(name));
         new PutUser(this.users).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CREATED_201);
@@ -99,7 +99,7 @@ class PutUserTest {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         final var name = "Alice";
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.body()).thenReturn(this.rqBody(name));
         new PutUser(this.users).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CREATED_201);
@@ -128,7 +128,7 @@ class PutUserTest {
     void returnBadRequest(final String body) {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn("Alice");
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn("Alice");
         Mockito.when(rqs.body()).thenReturn(body);
         new PutUser(this.users).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
@@ -146,7 +146,7 @@ class PutUserTest {
         );
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
-        Mockito.when(rqs.params(GetUser.USER_PARAM)).thenReturn(name);
+        Mockito.when(rqs.params(GetUser.USER_PARAM.toString())).thenReturn(name);
         new PutUser(this.users).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CONFLICT_409);
     }


### PR DESCRIPTION
Add `RequestPath` class with `RequestPath.Param` nested class
to encpauslate request params parsing and route path building logic.
Now same request param can be shared as `static final` field
and parsed without accessing its internal details.

Ref: #4 #5