### PR TITLE
feat: head storage alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,23 @@ Returns the list of the existing storage aliases as json object:
 }
 ```
 
+> **GET** /repositories/{repo}/storages/{alias}  
+> **GET** /storages/{uid}/{alias}
+
+Obtain details about storage alias `{alias}`, response is provided as json object:
+```json
+{
+  "type": "file",
+  "path": "/data/default"
+}
+```
+If the storage alias `{alias}` does not exist, status `404` is returned.
+
+> **HEAD** /repositories/{repo}/storages/{alias}  
+> **HEAD** /storages/{uid}/{alias}
+
+If the storage alias `{alias}` exist, status `302` is returned, status `404` is returned otherwise.
+
 > **PUT** /repositories/{repo}/storages/{alias}  
 > **PUT** /storages/{uid}/{alias}
 

--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -46,6 +46,7 @@ import spark.ExceptionHandler;
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @checkstyle JavaNCSSCheck (500 lines)
+ * @checkstyle MethodLengthCheck (500 lines)
  */
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveMethodLength"})
 public final class Service {
@@ -173,7 +174,15 @@ public final class Service {
                         this.ignite.get(
                             repo.with("storages").toString(),
                             MimeTypes.Type.APPLICATION_JSON.asString(),
+                            new Storages.GetAll(this.settings.repoConfigsStorage())
+                        );
+                        this.ignite.get(
+                            repo.with("storages").with(Storages.ST_ALIAS).toString(),
                             new Storages.Get(this.settings.repoConfigsStorage())
+                        );
+                        this.ignite.head(
+                            repo.with("storages").with(Storages.ST_ALIAS).toString(),
+                            new Storages.Head(this.settings.repoConfigsStorage())
                         );
                         this.ignite.delete(
                             repo.with("storages").with(Storages.ST_ALIAS).toString(),
@@ -190,7 +199,16 @@ public final class Service {
                         final RequestPath usr = this.userPath();
                         this.ignite.get(
                             usr.toString(), MimeTypes.Type.APPLICATION_JSON.asString(),
+                            new Storages.GetAll(this.settings.repoConfigsStorage())
+                        );
+                        this.ignite.get(
+                            usr.with(Storages.ST_ALIAS).toString(),
+                            MimeTypes.Type.APPLICATION_JSON.asString(),
                             new Storages.Get(this.settings.repoConfigsStorage())
+                        );
+                        this.ignite.head(
+                            usr.with(Storages.ST_ALIAS).toString(),
+                            new Storages.Head(this.settings.repoConfigsStorage())
                         );
                         this.ignite.delete(
                             usr.with(Storages.ST_ALIAS).toString(),

--- a/src/test/java/com/artipie/front/api/StoragesDeleteTest.java
+++ b/src/test/java/com/artipie/front/api/StoragesDeleteTest.java
@@ -43,7 +43,7 @@ class StoragesDeleteTest {
         ",,_storages.yml"
     })
     void removesStorage(final String uid, final String repo, final String key) {
-        StoragesGetTest.createSettings(this.blsto, new Key.From(key));
+        StoragesGetAllTest.createSettings(this.blsto, new Key.From(key));
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);

--- a/src/test/java/com/artipie/front/api/StoragesGetAllTest.java
+++ b/src/test/java/com/artipie/front/api/StoragesGetAllTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.api;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import java.nio.charset.StandardCharsets;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
+import spark.Request;
+import spark.Response;
+
+/**
+ * Test for {@link Storages.GetAll}.
+ * @since 0.1
+ */
+class StoragesGetAllTest {
+
+    /**
+     * Test storage.
+     */
+    private BlockingStorage blsto;
+
+    @BeforeEach
+    void init() {
+        this.blsto = new BlockingStorage(new InMemoryStorage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "alice,my-maven,alice/my-maven/_storages.yml",
+        "alice,,alice/_storages.yml",
+        ",internal-pypi,internal-pypi/_storages.yaml",
+        ",,_storages.yml"
+    })
+    void returnStorages(final String uid, final String repo, final String key)
+        throws JSONException {
+        StoragesGetAllTest.createSettings(this.blsto, new Key.From(key));
+        final var resp = Mockito.mock(Response.class);
+        final var rqs = Mockito.mock(Request.class);
+        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);
+        Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(uid);
+        final String handle = new Storages.GetAll(this.blsto).handle(rqs, resp);
+        JSONAssert.assertEquals(
+            handle,
+            String.join(
+                "\n",
+                "{\"storages\": {",
+                "  \"default\": {\"type\":\"file\",\"path\":\"/data/default\"},",
+                "  \"temp\": {\"type\":\"file\",\"path\":\"/data/temp\"},",
+                "  \"mounted\": {\"type\":\"file\",\"path\":\"/data/mounted\"}",
+                "  }",
+                "}"
+            ),
+            true
+        );
+    }
+
+    static void createSettings(final BlockingStorage blsto, final Key key) {
+        YamlMappingBuilder builder = Yaml.createYamlMappingBuilder();
+        for (final String alias : new String[]{"default", "temp", "mounted"}) {
+            builder = builder.add(
+                alias,
+                Yaml.createYamlMappingBuilder().add("type", "file")
+                    .add("path", String.format("/data/%s", alias)).build()
+            );
+        }
+        blsto.save(
+            key,
+            Yaml.createYamlMappingBuilder().add("storages", builder.build())
+                .build().toString().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/front/api/StoragesHeadTest.java
+++ b/src/test/java/com/artipie/front/api/StoragesHeadTest.java
@@ -8,21 +8,19 @@ import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import org.eclipse.jetty.http.HttpStatus;
-import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
-import org.skyscreamer.jsonassert.JSONAssert;
 import spark.Request;
 import spark.Response;
 
 /**
- * Test for {@link Storages.Get}.
+ * Test for {@link Storages.Head}.
  * @since 0.1
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class StoragesGetTest {
+class StoragesHeadTest {
 
     /**
      * Test storage.
@@ -36,31 +34,27 @@ class StoragesGetTest {
 
     @ParameterizedTest
     @CsvSource({
-        "olga,my-nuget,olga/my-nuget/_storages.yml",
-        "olga,,olga/_storages.yml",
-        ",internal-rpm,internal-rpm/_storages.yaml",
+        "richard,my-conan,richard/my-conan/_storages.yml",
+        "richard,,richard/_storages.yml",
+        ",internal-bin,internal-bin/_storages.yaml",
         ",,_storages.yml"
     })
-    void returnsStorageAliasDetails(final String uid, final String repo, final String key)
-        throws JSONException {
+    void returnsStorageAliasDetails(final String uid, final String repo, final String key) {
         StoragesGetAllTest.createSettings(this.blsto, new Key.From(key));
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(uid);
-        Mockito.when(rqs.params(Storages.ST_ALIAS.toString())).thenReturn("temp");
-        JSONAssert.assertEquals(
-            new Storages.Get(this.blsto).handle(rqs, resp),
-            "{\"type\": \"file\", \"path\": \"/data/temp\" }",
-            true
-        );
+        Mockito.when(rqs.params(Storages.ST_ALIAS.toString())).thenReturn("default");
+        new Storages.Head(this.blsto).handle(rqs, resp);
+        Mockito.verify(resp).status(HttpStatus.FOUND_302);
     }
 
     @ParameterizedTest
     @CsvSource({
-        "ivan,my-maven,ivan/my-maven/_storages.yml",
-        "ivan,,ivan/_storages.yml",
-        ",internal-gem,internal-gem/_storages.yaml",
+        "jane,my-maven,jane/my-maven/_storages.yml",
+        "jane,,jane/_storages.yml",
+        ",internal-python,internal-python/_storages.yaml",
         ",,_storages.yml"
     })
     void returnsNotFoundWhenAliasNotExists(final String uid, final String repo,
@@ -71,7 +65,7 @@ class StoragesGetTest {
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(uid);
         Mockito.when(rqs.params(Storages.ST_ALIAS.toString())).thenReturn("local");
-        new Storages.Get(this.blsto).handle(rqs, resp);
+        new Storages.Head(this.blsto).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.NOT_FOUND_404);
     }
 

--- a/src/test/java/com/artipie/front/api/StoragesPutTest.java
+++ b/src/test/java/com/artipie/front/api/StoragesPutTest.java
@@ -43,7 +43,7 @@ class StoragesPutTest {
         ",,_storages.yml"
     })
     void addsStorageAlias(final String uid, final String repo, final String key) {
-        StoragesGetTest.createSettings(this.blsto, new Key.From(key));
+        StoragesGetAllTest.createSettings(this.blsto, new Key.From(key));
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);
@@ -84,7 +84,7 @@ class StoragesPutTest {
     })
     void returnsConflictWhenAliasAlreadyExists(final String uid, final String repo,
         final String key) {
-        StoragesGetTest.createSettings(this.blsto, new Key.From(key));
+        StoragesGetAllTest.createSettings(this.blsto, new Key.From(key));
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(repo);


### PR DESCRIPTION
Closes #5 
Added `GET` and `HEAD` endpoints for storage aliases API, thus API endpoints are similar for repositories, users and storage aliases. 