### PR TITLE
feat(auth): permissions filter

### DIFF
--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -11,7 +11,9 @@ import com.artipie.front.api.Repositories;
 import com.artipie.front.api.RepositoryPermissions;
 import com.artipie.front.api.Storages;
 import com.artipie.front.api.Users;
+import com.artipie.front.auth.AccessFilter;
 import com.artipie.front.auth.AuthByPassword;
+import com.artipie.front.auth.AuthPermissions;
 import com.artipie.front.internal.HealthRoute;
 import com.artipie.front.misc.RequestPath;
 import com.artipie.front.settings.ArtipieYaml;
@@ -129,6 +131,7 @@ public final class Service {
         this.ignite.path(
             "/api", () -> {
                 this.ignite.before("/*", new ApiAuthFilter((tkn, time) -> "anonymous"));
+                this.ignite.before("/*", new AccessFilter(AuthPermissions.STUB));
                 this.ignite.path(
                     "/repositories", () -> {
                         final RepoSettings stn = new RepoSettings(

--- a/src/main/java/com/artipie/front/auth/AccessFilter.java
+++ b/src/main/java/com/artipie/front/auth/AccessFilter.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import com.artipie.front.RequestAttr;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.jetty.http.HttpStatus;
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+import wtf.g4s8.tuples.Pair;
+
+/**
+ * Access HTTP filter.
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class AccessFilter implements Filter {
+
+    /**
+     * Permissions allowed to handle request.
+     */
+    private static final Map<Pair<String, String>, Collection<String>> PERM_REQ = Map.of(
+        Pair.of("GET", "/repositories.*"), List.of("repo-read"),
+        Pair.of("HEAD", "/repositories.*"), List.of("repo-read"),
+        Pair.of("PUT", "/repositories.*"), List.of("repo-write"),
+        Pair.of("DELETE", "/repositories.*"), List.of("repo-write")
+    );
+
+    /**
+     * Permissions.
+     */
+    private final AuthPermissions perms;
+
+    /**
+     * Access filter.
+     * @param perms Permissions
+     */
+    public AccessFilter(final AuthPermissions perms) {
+        this.perms = perms;
+    }
+
+    @Override
+    public void handle(final Request req, final Response rsp) throws Exception {
+        final var uid = RequestAttr.Standard.USER_ID.read(req);
+        if (uid.isEmpty()) {
+            Spark.halt(HttpStatus.UNAUTHORIZED_401, "Authentication required");
+        }
+        final boolean allowed = AccessFilter.PERM_REQ.getOrDefault(
+            Pair.of(req.requestMethod(), req.pathInfo()), Collections.emptyList()
+        ).stream().anyMatch(perm -> this.perms.allowed(uid.get(), perm));
+        if (!allowed) {
+            Spark.halt(HttpStatus.FORBIDDEN_403, "Request is not allowed");
+        }
+    }
+}

--- a/src/main/java/com/artipie/front/auth/AuthPermissions.java
+++ b/src/main/java/com/artipie/front/auth/AuthPermissions.java
@@ -1,0 +1,26 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+/**
+ * Authorization permissions.
+ * @since 1.0
+ */
+public interface AuthPermissions {
+
+    /**
+     * Stub permissions for development and debugging.
+     * Remove after actual implementation.
+     */
+    AuthPermissions STUB = (uid, perm) -> true;
+
+    /**
+     * Check if permissions is allowed for user.
+     * @param uid User ID
+     * @param perm Permission name
+     * @return True if allowed
+     */
+    boolean allowed(String uid, String perm);
+}


### PR DESCRIPTION
Add `AuthPermissions` interface and stub impl.
Add spark filter with some permissions for `/repositories`.

Ticket: #4