### PR TITLE
test: added ITs for repository permissions API

### DIFF
--- a/src/main/java/com/artipie/front/api/RepositoryPermissions.java
+++ b/src/main/java/com/artipie/front/api/RepositoryPermissions.java
@@ -74,7 +74,7 @@ public final class RepositoryPermissions {
                 Json.createReader(new StringReader(request.body())).readArray()
             );
             response.status(HttpStatus.CREATED_201);
-            return null;
+            return "";
         }
     }
 
@@ -143,7 +143,7 @@ public final class RepositoryPermissions {
                 RepositoryPermissions.NAME.parse(request)
             );
             response.status(HttpStatus.OK_200);
-            return null;
+            return "";
         }
     }
 
@@ -178,7 +178,7 @@ public final class RepositoryPermissions {
                 Json.createReader(new StringReader(request.body())).readObject()
             );
             response.status(HttpStatus.OK_200);
-            return null;
+            return "";
         }
     }
 }

--- a/src/test/java/com/artipie/front/RepoPermITCase.java
+++ b/src/test/java/com/artipie/front/RepoPermITCase.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front;
+
+import java.util.Arrays;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Tests for repository permissions.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RepoPermITCase {
+
+    /**
+     * Test deployments.
+     * @checkstyle VisibilityModifierCheck (10 lines)
+     */
+    @RegisterExtension
+    final TestService service = new TestService()
+        .withResource(TestService.CREDS, "RepoPermITCase/_credentials.yaml")
+        .withResource("_api_permissions.yml", "RepoPermITCase/_api_permissions.yml")
+        .withResource("repos/pypi-repo.yaml", "RepoPermITCase/pypi-repo.yaml");
+
+    /**
+     * Test http client.
+     */
+    private TestClient client;
+
+    @BeforeEach
+    void init() {
+        this.client = new TestClient(this.service.port());
+    }
+
+    @Test
+    void canManageRepoPermissions() {
+        final String alice = this.client.token("Alice", "wonderland");
+        MatcherAssert.assertThat(
+            "Failed to obtain auth token for Alice", alice, new IsNot<>(Matchers.emptyString())
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/pypi-repo/permissions", alice),
+            new StringContainsInOrder(Arrays.asList("Aladdin", "read"))
+        );
+        final String aladdin = this.client.token("Aladdin", "opensesame");
+        MatcherAssert.assertThat(
+            "Aladdin failed to put perms",
+            this.client.put(
+                "/api/repositories/pypi-repo/permissions/Aladdin", aladdin, "[\"write\", \"tag\"]"
+            ),
+            new IsEqual<>(HttpStatus.CREATED_201)
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/pypi-repo/permissions", alice),
+            new StringContainsInOrder(Arrays.asList("Aladdin", "write", "tag"))
+        );
+        MatcherAssert.assertThat(
+            "Aladdin failed to patch permissions",
+            this.client.patch(
+                "/api/repositories/pypi-repo/permissions", aladdin,
+                String.join(
+                    "\n",
+                    "{",
+                    "  \"grant\" : {",
+                    "    \"Elen\": [\"write\", \"read\"],",
+                    "    \"Alice\": [\"read\"]",
+                    "  },",
+                    "  \"revoke\": {",
+                    "    \"Aladdin\": [\"write\"]",
+                    "  }",
+                    "}"
+                )
+            ),
+            new IsEqual<>(HttpStatus.OK_200)
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/pypi-repo/permissions", alice),
+            new StringContainsInOrder(
+                Arrays.asList("Aladdin", "tag", "Elen", "write", "read", "Alice", "read")
+            )
+        );
+        MatcherAssert.assertThat(
+            "Aladdin failed to remove perms",
+            this.client.delete("/api/repositories/pypi-repo/permissions/Aladdin", aladdin),
+            new IsEqual<>(HttpStatus.OK_200)
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/pypi-repo/permissions", alice),
+            new StringContainsInOrder(
+                Arrays.asList("Elen", "write", "read", "Alice", "read")
+            )
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/front/TestClient.java
+++ b/src/test/java/com/artipie/front/TestClient.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
@@ -123,6 +124,30 @@ public final class TestClient {
      */
     int put(final String line, final String token, final String body) {
         final HttpPut request = new HttpPut(
+            String.format("http://localhost:%d%s", this.port, line)
+        );
+        request.addHeader(HttpHeader.AUTHORIZATION.toString(), token);
+        request.addHeader(
+            HttpHeader.CONTENT_TYPE.toString(),
+            MimeTypes.Type.APPLICATION_JSON.asString()
+        );
+        request.setEntity(new ByteArrayEntity(body.getBytes(StandardCharsets.UTF_8)));
+        try (CloseableHttpResponse response = this.client.execute(request)) {
+            return response.getStatusLine().getStatusCode();
+        } catch (final IOException err) {
+            throw new UncheckedIOException(err);
+        }
+    }
+
+    /**
+     * Perform patch request with provided body and return response status.
+     * @param line Request line
+     * @param token User token
+     * @param body Response body
+     * @return Response status
+     */
+    int patch(final String line, final String token, final String body) {
+        final HttpPatch request = new HttpPatch(
             String.format("http://localhost:%d%s", this.port, line)
         );
         request.addHeader(HttpHeader.AUTHORIZATION.toString(), token);

--- a/src/test/resources/RepoPermITCase/_api_permissions.yml
+++ b/src/test/resources/RepoPermITCase/_api_permissions.yml
@@ -1,0 +1,13 @@
+endpoints:
+  "/repositories/.*/permissions.*":
+    "GET":
+      - perms-read
+    "PUT|DELETE|PATCH":
+      - perms-write
+
+users:
+  Alice:
+    - perms-read
+  Aladdin:
+    - perms-write
+    - perms-read

--- a/src/test/resources/RepoPermITCase/_credentials.yaml
+++ b/src/test/resources/RepoPermITCase/_credentials.yaml
@@ -1,0 +1,7 @@
+credentials:
+  Alice:
+    type: plain
+    pass: wonderland
+  Aladdin:
+    type: plain
+    pass: opensesame

--- a/src/test/resources/RepoPermITCase/pypi-repo.yaml
+++ b/src/test/resources/RepoPermITCase/pypi-repo.yaml
@@ -1,0 +1,8 @@
+repo:
+  type: pypi
+  storage:
+    type: fs
+    path: /var/artipie/data/pypi
+  permissions:
+    Aladdin:
+      - read


### PR DESCRIPTION
Part of #60 
Added ITs for repository permissions API, fixed some endpoints not to return nulls.