### PR TITLE
test: added ITs with `org` layout

### DIFF
--- a/src/test/java/com/artipie/front/OrgLayoutITCase.java
+++ b/src/test/java/com/artipie/front/OrgLayoutITCase.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Test for service with `org` layout.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class OrgLayoutITCase {
+
+    /**
+     * Test deployments.
+     * @checkstyle VisibilityModifierCheck (10 lines)
+     */
+    @RegisterExtension
+    final TestService service = new TestService("org")
+        .withResource(TestService.CREDS, "OrgLayoutITCase/_credentials.yaml")
+        .withResource("_api_permissions.yml", "OrgLayoutITCase/_api_permissions.yml")
+        .withResource("repos/Alice/pypi-repo.yaml", "OrgLayoutITCase/pypi-repo.yaml")
+        .withResource("repos/Aladdin/maven/_storages.yaml", "OrgLayoutITCase/_storages.yaml");
+
+    /**
+     * Test http client.
+     */
+    private TestClient client;
+
+    @BeforeEach
+    void init() {
+        this.client = new TestClient(this.service.port());
+    }
+
+    @Test
+    void canManageRepoPerms() {
+        final String alice = this.client.token("Alice", "wonderland");
+        MatcherAssert.assertThat(
+            "Failed to obtain auth token for Alice", alice, new IsNot<>(Matchers.emptyString())
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/Alice/pypi-repo/permissions", alice),
+            new StringContainsInOrder(Arrays.asList("Alice", "read"))
+        );
+        final String aladdin = this.client.token("Aladdin", "opensesame");
+        MatcherAssert.assertThat(
+            "Aladdin failed to put perms",
+            this.client.put(
+                "/api/repositories/Alice/pypi-repo/permissions/Aladdin",
+                aladdin, "[\"write\", \"tag\"]"
+            ),
+            new IsEqual<>(HttpStatus.CREATED_201)
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to remove perms",
+            this.client.delete("/api/repositories/Alice/pypi-repo/permissions/Alice", alice),
+            new IsEqual<>(HttpStatus.OK_200)
+        );
+        MatcherAssert.assertThat(
+            "Alice failed to get perms",
+            this.client.get("/api/repositories/Alice/pypi-repo/permissions", alice),
+            new StringContainsInOrder(Arrays.asList("Aladdin", "write", "tag"))
+        );
+    }
+
+    @Test
+    void canManageStorageAliases() {
+        final String alice = this.client.token("Alice", "wonderland");
+        MatcherAssert.assertThat(
+            "Failed to obtain auth token for Alice", alice, new IsNot<>(Matchers.emptyString())
+        );
+        MatcherAssert.assertThat(
+            "Alice can get all storages info",
+            this.client.get("/api/repositories/Aladdin/maven/storages", alice),
+            new StringContainsInOrder(Arrays.asList("default", "temp"))
+        );
+        final String aladdin = this.client.token("Aladdin", "opensesame");
+        MatcherAssert.assertThat(
+            "Aladdin can add storage alias",
+            this.client.put(
+                "/api/repositories/Aladdin/maven/storages/local", aladdin,
+                "{ \"type\": \"file\", \"path\": \"/usr/local\" }"
+            ),
+            new IsEqual<>(HttpStatus.CREATED_201)
+        );
+        MatcherAssert.assertThat(
+            "Alice can delete storage alias",
+            this.client.delete("/api/repositories/Aladdin/maven/storages/temp", alice),
+            new IsEqual<>(HttpStatus.OK_200)
+        );
+        MatcherAssert.assertThat(
+            "Alice can get all storages info",
+            this.client.get("/api/repositories/Aladdin/maven/storages", alice),
+            new StringContainsInOrder(Arrays.asList("default", "local"))
+        );
+    }
+
+    @AfterEach
+    void stop() throws IOException {
+        this.client.close();
+    }
+
+}

--- a/src/test/java/com/artipie/front/TestService.java
+++ b/src/test/java/com/artipie/front/TestService.java
@@ -40,6 +40,11 @@ public final class TestService implements BeforeEachCallback, AfterEachCallback 
     private final Path tmp;
 
     /**
+     * Artipie layout.
+     */
+    private final String layout;
+
+    /**
      * Test service instance.
      */
     private Service service;
@@ -51,14 +56,23 @@ public final class TestService implements BeforeEachCallback, AfterEachCallback 
 
     /**
      * Ctor.
+     * @param layout Artipie layout
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public TestService() {
+    public TestService(final String layout) {
+        this.layout = layout;
         try {
             this.tmp = Files.createTempDirectory("front-it-case");
         } catch (final IOException err) {
             throw new UncheckedIOException(err);
         }
+    }
+
+    /**
+     * Ctor.
+     */
+    public TestService() {
+        this("flat");
     }
 
     @Override
@@ -73,7 +87,8 @@ public final class TestService implements BeforeEachCallback, AfterEachCallback 
                     Optional.of(
                         Yaml.createYamlMappingBuilder().add("type", "file")
                             .add("path", TestService.CREDS).build()
-                    )
+                    ),
+                    this.layout
                 )
             )
         );

--- a/src/test/java/com/artipie/front/settings/ArtipieYamlTest.java
+++ b/src/test/java/com/artipie/front/settings/ArtipieYamlTest.java
@@ -165,6 +165,12 @@ public final class ArtipieYamlTest {
 
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static YamlMapping config(final String stpath, final Optional<YamlNode> creds) {
+        return ArtipieYamlTest.config(stpath, creds, "flat");
+    }
+
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static YamlMapping config(final String stpath, final Optional<YamlNode> creds,
+        final String layout) {
         YamlMappingBuilder meta = Yaml.createYamlMappingBuilder()
             .add(
                 "storage",
@@ -172,7 +178,8 @@ public final class ArtipieYamlTest {
                     .add("type", "fs")
                     .add("path", stpath).build()
             )
-            .add("repo_configs", "repos");
+            .add("repo_configs", "repos")
+            .add("layout", layout);
         if (creds.isPresent()) {
             meta = meta.add("credentials", creds.get());
         }

--- a/src/test/resources/OrgLayoutITCase/_api_permissions.yml
+++ b/src/test/resources/OrgLayoutITCase/_api_permissions.yml
@@ -1,0 +1,13 @@
+endpoints:
+  "/repositories.*":
+    "GET|HEAD":
+      - repo-read
+    "PUT|DELETE|POST|PATCH":
+      - repo-write
+
+users:
+  Alice:
+    - repo-read
+    - repo-write
+  Aladdin:
+    - repo-write

--- a/src/test/resources/OrgLayoutITCase/_credentials.yaml
+++ b/src/test/resources/OrgLayoutITCase/_credentials.yaml
@@ -1,0 +1,7 @@
+credentials:
+  Alice:
+    type: plain
+    pass: wonderland
+  Aladdin:
+    type: plain
+    pass: opensesame

--- a/src/test/resources/OrgLayoutITCase/_storages.yaml
+++ b/src/test/resources/OrgLayoutITCase/_storages.yaml
@@ -1,0 +1,7 @@
+storages:
+  default:
+    type: file
+    path: /usr/local/def
+  temp:
+    type: file
+    path: /usr/tmp

--- a/src/test/resources/OrgLayoutITCase/pypi-repo.yaml
+++ b/src/test/resources/OrgLayoutITCase/pypi-repo.yaml
@@ -1,0 +1,8 @@
+repo:
+  type: pypi
+  storage:
+    type: fs
+    path: /var/artipie/data/pypi
+  permissions:
+    Alice:
+      - read


### PR DESCRIPTION
Closes #60 
Finished integration tests with adding ITs for the service with `org` layout.