### PR TITLE
feat: `move` operation for repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
-target/**
-.classpath
-.project
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
 .settings/**
-.vscode/**
+.project
+.classpath
+target/**
+.idea/**
+http.iml

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ to learn more about different repositories settings.
 Deletes repository called `{name}`, returns status `200` on success, status `404` if repository does
 not exist.
 
+> **PUT** /repository/{name}/move
+
+Renames repository and moves all the data. Json with the new name is expected in the request body:
+
+```json
+{ 
+  "new_name" : "repo_new_name"
+}
+```
+Returns response status `200` if operation was successful.
+
 ### Repository permissions API
 
 > **GET** /repositories/{repo}/permissions

--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -171,6 +171,7 @@ public final class Service {
                         this.ignite.head(path.toString(), new Repositories.Head(stn));
                         this.ignite.delete(path.toString(), new Repositories.Delete(stn));
                         this.ignite.put(path.toString(), new Repositories.Put(stn));
+                        this.ignite.put(path.with("move").toString(), new Repositories.Move(stn));
                         final RequestPath repo = this.repoPath();
                         this.ignite.get(
                             repo.with("permissions").toString(),

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -252,7 +252,7 @@ public final class Repositories {
 
     /**
      * Handle `PUT` request to rename the repository, request line example:
-     * PUT /repositories/move/{repo_name}
+     * PUT /repositories/{repo_name}/move
      * where {repo_name} is the name of the repository. In the case of `org` layout,
      * repository owner is obtained from request attributes. Json with repository
      * new name (field `new_name`) is expected in the request body.

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -249,4 +249,50 @@ public final class Repositories {
             return "";
         }
     }
+
+    /**
+     * Handle `PUT` request to rename the repository, request line example:
+     * PUT /repositories/move/{repo_name}
+     * where {repo_name} is the name of the repository. In the case of `org` layout,
+     * repository owner is obtained from request attributes. Json with repository
+     * new name (field `new_name`) is expected in the request body.
+     *
+     * @since 0.1
+     * @checkstyle ReturnCountCheck (500 lines)
+     */
+    public static final class Move implements Route {
+
+        /**
+         * Repository settings.
+         */
+        private final RepoSettings stn;
+
+        /**
+         * Ctor.
+         * @param stn Repository settings
+         */
+        public Move(final RepoSettings stn) {
+            this.stn = stn;
+        }
+
+        @Override
+        @SuppressWarnings("PMD.OnlyOneReturn")
+        public Object handle(final Request request, final Response response) {
+            final String param = REPO_PARAM.parse(request);
+            final String uid = RequestAttr.Standard.USER_ID.readOrThrow(request);
+            if (!this.stn.exists(param, uid)) {
+                response.status(HttpStatus.BAD_REQUEST_400);
+                return String.format("Repository does not %s exist", param);
+            }
+            final String nname = Json.createReader(new StringReader(request.body()))
+                .readObject().getString("new_name");
+            if (nname == null) {
+                response.status(HttpStatus.BAD_REQUEST_400);
+                return "Field `new_name` is required";
+            }
+            this.stn.move(param, uid, nname);
+            response.status(HttpStatus.OK_200);
+            return "";
+        }
+    }
 }

--- a/src/main/java/com/artipie/front/settings/RepoSettings.java
+++ b/src/main/java/com/artipie/front/settings/RepoSettings.java
@@ -136,6 +136,17 @@ public final class RepoSettings {
     }
 
     /**
+     * Moves repository settings.
+     * @param name Repository name
+     * @param uid User id (=name)
+     * @param nname New name
+     * @throws NotFoundException If such repository does not exist
+     */
+    public void move(final String name, final String uid, final String nname) {
+        this.repos.move(this.key(name, uid), this.keys(nname, uid).getRight());
+    }
+
+    /**
      * Returns a pair of keys, these keys are possible repository settings names.
      * @param name Repository name
      * @param uid User id (=name)

--- a/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.api;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.front.RequestAttr;
+import com.artipie.front.settings.RepoSettings;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import spark.Request;
+import spark.Response;
+
+/**
+ * Test for {@link Repositories.Move}.
+ * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RepositoriesMoveTest {
+
+    /**
+     * Test repository settings.
+     */
+    private static final String REPO = String.join(
+        System.lineSeparator(),
+        "repo:",
+        "  type: rpm",
+        "  storage:",
+        "    type: fs",
+        "    path: /var/artipie/data/"
+    );
+
+    /**
+     * Test storage.
+     */
+    private BlockingStorage blsto;
+
+    @BeforeEach
+    void init() {
+        this.blsto = new BlockingStorage(new InMemoryStorage());
+    }
+
+    @Test
+    void movesRepo() {
+        final var resp = Mockito.mock(Response.class);
+        final var rqs = Mockito.mock(Request.class);
+        final Key.From key = new Key.From("my-rpm.yml");
+        this.blsto.save(key, RepositoriesMoveTest.REPO.getBytes(StandardCharsets.UTF_8));
+        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-rpm");
+        Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
+        Mockito.when(rqs.body()).thenReturn("{ \"new_name\": \"alice-rpm\"}");
+        MatcherAssert.assertThat(
+            "Failed to return empty response",
+            new Repositories.Move(new RepoSettings("flat", this.blsto)).handle(rqs, resp),
+            new IsAnything<>()
+        );
+        Mockito.verify(resp).status(HttpStatus.OK_200);
+        MatcherAssert.assertThat(
+            "Failed to read repository settings",
+            new String(this.blsto.value(new Key.From("alice-rpm.yml")), StandardCharsets.UTF_8),
+            new IsEqual<>(RepositoriesMoveTest.REPO)
+        );
+        MatcherAssert.assertThat(
+            "Repo with old name should not exist",
+            this.blsto.exists(key),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void returnsBadRequestWhenReqIsInvalid() {
+        final var resp = Mockito.mock(Response.class);
+        final var rqs = Mockito.mock(Request.class);
+        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-maven");
+        Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
+        Mockito.when(rqs.body()).thenReturn("{ }");
+        new Repositories.Move(new RepoSettings("org", this.blsto)).handle(rqs, resp);
+        Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void returnsBadRequestWhenRepoDoesNotExist() {
+        final String jane = "Jane";
+        final var resp = Mockito.mock(Response.class);
+        final var rqs = Mockito.mock(Request.class);
+        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-docker");
+        Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(jane);
+        new Repositories.Move(new RepoSettings("org", this.blsto)).handle(rqs, resp);
+        Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
+    }
+
+}


### PR DESCRIPTION
Part of https://github.com/artipie/artipie/issues/923

Added endpoint to rename repository configuration file, test and added description into readme. 

Repository data are not actually moved now, this operation will be implemented in the next step.