### PR TITLE
feat: remove and move data from storage

### DIFF
--- a/src/main/java/com/artipie/front/settings/RepoData.java
+++ b/src/main/java/com/artipie/front/settings/RepoData.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.settings;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Copy;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.SubStorage;
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+import org.apache.commons.lang3.NotImplementedException;
+
+/**
+ * Repository data management.
+ * @since 0.1
+ */
+public final class RepoData {
+
+    /**
+     * Repository settings.
+     */
+    private final RepoSettings stn;
+
+    /**
+     * Ctor.
+     * @param stn Repository settings
+     */
+    public RepoData(final RepoSettings stn) {
+        this.stn = stn;
+    }
+
+    /**
+     * Remove data from the repository.
+     * @param name Repository name
+     * @param uid User name
+     * @return Completable action of the remove operation
+     */
+    public CompletionStage<Void> remove(final String name, final String uid) {
+        final String repo = this.stn.name(name, uid);
+        return this.asto(name, uid).deleteAll(new Key.From(repo)).thenAccept(
+            nothing -> Logger.info(this, String.format("Removed data from repository %s", repo))
+        );
+    }
+
+    /**
+     * Remove data from the repository.
+     * @param name Repository name
+     * @param uid User name
+     * @param nname New name
+     * @return Completable action of the remove operation
+     */
+    public CompletionStage<Void> move(final String name, final String uid, final String nname) {
+        final Key repo = new Key.From(this.stn.name(name, uid));
+        final String nrepo = this.stn.name(nname, uid);
+        final Storage asto = this.asto(name, uid);
+        return new SubStorage(repo, asto).list(Key.ROOT).thenCompose(
+            list -> new Copy(new SubStorage(repo, asto), list)
+                .copy(new SubStorage(new Key.From(nrepo), asto))
+        ).thenCompose(nothing -> asto.deleteAll(new Key.From(repo))).thenAccept(
+            nothing ->
+                Logger.info(this, String.format("Moved data from repository %s to %s", repo, nrepo))
+        );
+    }
+
+    /**
+     * Obtain storage from repository settings.
+     * @param name Repository name
+     * @param uid User name
+     * @return Abstract storage
+     */
+    private Storage asto(final String name, final String uid) {
+        final Storage asto;
+        try {
+            final YamlMapping yaml = Yaml.createYamlInput(
+                new String(this.stn.value(name, uid), StandardCharsets.UTF_8)
+            ).readYamlMapping().yamlMapping("repo");
+            final YamlMapping storage = yaml.yamlMapping("storage");
+            if (storage == null) {
+                throw new NotImplementedException("Not implemented yet");
+            } else {
+                asto = new YamlStorage(storage).storage();
+            }
+            return asto;
+        } catch (final IOException err) {
+            throw new UncheckedIOException(err);
+        }
+    }
+}

--- a/src/main/java/com/artipie/front/settings/RepoSettings.java
+++ b/src/main/java/com/artipie/front/settings/RepoSettings.java
@@ -147,6 +147,20 @@ public final class RepoSettings {
     }
 
     /**
+     * Returns repository name, the same as settings file key, but without yaml extension.
+     * @param name Repository name
+     * @param uid User id (=name)
+     * @return String name
+     */
+    public String name(final String name, final String uid) {
+        String res = name;
+        if (this.layout.equals("org")) {
+            res = String.format("%s/%s", uid, name);
+        }
+        return res;
+    }
+
+    /**
      * Returns a pair of keys, these keys are possible repository settings names.
      * @param name Repository name
      * @param uid User id (=name)

--- a/src/test/java/com/artipie/front/settings/RepoDataTest.java
+++ b/src/test/java/com/artipie/front/settings/RepoDataTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.settings;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test for {@link RepoData}.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RepoDataTest {
+
+    /**
+     * Test repository name.
+     */
+    private static final String REPO = "my-repo";
+
+    /**
+     * Temp dir.
+     * @checkstyle VisibilityModifierCheck (500 lines)
+     */
+    @TempDir
+    Path temp;
+
+    /**
+     * Test settings storage.
+     */
+    private BlockingStorage stngs;
+
+    /**
+     * Test data storage.
+     */
+    private BlockingStorage data;
+
+    @BeforeEach
+    void init() {
+        this.stngs = new BlockingStorage(new InMemoryStorage());
+        this.data = new BlockingStorage(new FileStorage(this.temp));
+        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
+        this.stngs.save(
+            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettings().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    @Test
+    void removesData() {
+        new RepoData(new RepoSettings("flat", this.stngs)).remove(RepoDataTest.REPO, "any")
+            .toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository data are removed",
+            this.data.list(Key.ROOT).isEmpty()
+        );
+    }
+
+    @Test
+    void movesData() {
+        final String nrepo = "new-repo";
+        new RepoData(new RepoSettings("flat", this.stngs)).move(RepoDataTest.REPO, "any", nrepo)
+            .toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository data are moved",
+            this.data.list(Key.ROOT).stream().map(Key::string)
+                .collect(Collectors.toList()),
+            Matchers.contains("new-repo/first.txt", "new-repo/second.txt")
+        );
+    }
+
+    private String repoSettings() {
+        return String.join(
+            System.lineSeparator(),
+            "repo:",
+            "  type: binary",
+            "  storage:",
+            "    type: fs",
+            String.format("    path: %s", this.temp.toString())
+        );
+    }
+}


### PR DESCRIPTION
Part of https://github.com/artipie/artipie/issues/923 

Added class to remove or move data from repository storage when repository is renamed or deleted. Implementation is not full now, it only covers the case, when storage is fully defined in repository settings file, not in [storage aliases](https://github.com/artipie/artipie#storage-configuration). Case with the storage aliases will be implemented in the next step. 

Remove or move operations can take some time, there is no plan to wait for completion and keep the connection open in API request. 