### PR TITLE
feat: (re)move data on storage (re)move

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ to learn more about different repositories settings.
 > **DELETE** /repository/{name} 
 
 Deletes repository called `{name}`, returns status `200` on success, status `404` if repository does
-not exist.
+not exist. Repository data are removed asynchronously, success status does not guarantee, that 
+repo and data were already fully removed. After `delete` call `head` method on the repository 
+to check whether remove operation was complete and repository does not exist.
 
 > **PUT** /repository/{name}/move
 
@@ -116,7 +118,10 @@ Renames repository and moves all the data. Json with the new name is expected in
   "new_name" : "repo_new_name"
 }
 ```
-Returns response status `200` if operation was successful.
+Returns response status `200` if operation was successful. Repository data are moved 
+asynchronously, success status does not guarantee, that rename operation was fully complete. 
+Use `head` method on the repository with the previous name, if such repository does not exist, all
+the data were fully moved to the new repo.
 
 ### Repository permissions API
 

--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -172,16 +172,12 @@ public final class Service {
                         this.ignite.head(path.toString(), new Repositories.Head(stn));
                         this.ignite.delete(
                             path.toString(),
-                            new Repositories.Delete(
-                                stn, new RepoData(stn, this.settings.repoConfigsStorage())
-                            )
+                            new Repositories.Delete(stn, new RepoData(stn))
                         );
                         this.ignite.put(path.toString(), new Repositories.Put(stn));
                         this.ignite.put(
                             path.with("move").toString(),
-                            new Repositories.Move(
-                                stn, new RepoData(stn, this.settings.repoConfigsStorage())
-                            )
+                            new Repositories.Move(stn, new RepoData(stn))
                         );
                         final RequestPath repo = this.repoPath();
                         this.ignite.get(

--- a/src/main/java/com/artipie/front/Service.java
+++ b/src/main/java/com/artipie/front/Service.java
@@ -18,6 +18,7 @@ import com.artipie.front.auth.AuthByPassword;
 import com.artipie.front.internal.HealthRoute;
 import com.artipie.front.misc.RequestPath;
 import com.artipie.front.settings.ArtipieYaml;
+import com.artipie.front.settings.RepoData;
 import com.artipie.front.settings.RepoSettings;
 import com.artipie.front.settings.YamlRepoPermissions;
 import com.artipie.front.ui.HbTemplateEngine;
@@ -169,9 +170,19 @@ public final class Service {
                             new Repositories.Get(stn)
                         );
                         this.ignite.head(path.toString(), new Repositories.Head(stn));
-                        this.ignite.delete(path.toString(), new Repositories.Delete(stn));
+                        this.ignite.delete(
+                            path.toString(),
+                            new Repositories.Delete(
+                                stn, new RepoData(stn, this.settings.repoConfigsStorage())
+                            )
+                        );
                         this.ignite.put(path.toString(), new Repositories.Put(stn));
-                        this.ignite.put(path.with("move").toString(), new Repositories.Move(stn));
+                        this.ignite.put(
+                            path.with("move").toString(),
+                            new Repositories.Move(
+                                stn, new RepoData(stn, this.settings.repoConfigsStorage())
+                            )
+                        );
                         final RequestPath repo = this.repoPath();
                         this.ignite.get(
                             repo.with("permissions").toString(),

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -8,6 +8,7 @@ import com.artipie.front.RequestAttr;
 import com.artipie.front.misc.Json2Yaml;
 import com.artipie.front.misc.RequestPath;
 import com.artipie.front.misc.Yaml2Json;
+import com.artipie.front.settings.RepoData;
 import com.artipie.front.settings.RepoSettings;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -142,18 +143,30 @@ public final class Repositories {
         private final RepoSettings stn;
 
         /**
+         * Repository data.
+         */
+        private final RepoData data;
+
+        /**
          * Ctor.
          * @param stn Repository settings
+         * @param data Repository data
          */
-        public Delete(final RepoSettings stn) {
+        public Delete(final RepoSettings stn, final RepoData data) {
             this.stn = stn;
+            this.data = data;
         }
 
         @Override
         public Object handle(final Request request, final Response response) {
-            this.stn.delete(
+            this.data.remove(
                 REPO_PARAM.parse(request),
                 RequestAttr.Standard.USER_ID.readOrThrow(request)
+            ).thenAccept(
+                nothing -> this.stn.delete(
+                    REPO_PARAM.parse(request),
+                    RequestAttr.Standard.USER_ID.readOrThrow(request)
+                )
             );
             return "";
         }
@@ -268,11 +281,18 @@ public final class Repositories {
         private final RepoSettings stn;
 
         /**
+         * Repository data.
+         */
+        private final RepoData data;
+
+        /**
          * Ctor.
          * @param stn Repository settings
+         * @param data Repository data
          */
-        public Move(final RepoSettings stn) {
+        public Move(final RepoSettings stn, final RepoData data) {
             this.stn = stn;
+            this.data = data;
         }
 
         @Override
@@ -290,7 +310,9 @@ public final class Repositories {
                 response.status(HttpStatus.BAD_REQUEST_400);
                 return "Field `new_name` is required";
             }
-            this.stn.move(param, uid, nname);
+            this.data.move(param, uid, nname).thenAccept(
+                nothing -> this.stn.move(param, uid, nname)
+            );
             response.status(HttpStatus.OK_200);
             return "";
         }

--- a/src/main/java/com/artipie/front/api/Repositories.java
+++ b/src/main/java/com/artipie/front/api/Repositories.java
@@ -162,8 +162,8 @@ public final class Repositories {
             this.data.remove(
                 REPO_PARAM.parse(request),
                 RequestAttr.Standard.USER_ID.readOrThrow(request)
-            ).thenAccept(
-                nothing -> this.stn.delete(
+            ).thenRun(
+                () -> this.stn.delete(
                     REPO_PARAM.parse(request),
                     RequestAttr.Standard.USER_ID.readOrThrow(request)
                 )
@@ -310,8 +310,8 @@ public final class Repositories {
                 response.status(HttpStatus.BAD_REQUEST_400);
                 return "Field `new_name` is required";
             }
-            this.data.move(param, uid, nname).thenAccept(
-                nothing -> this.stn.move(param, uid, nname)
+            this.data.move(param, uid, nname).thenRun(
+                () -> this.stn.move(param, uid, nname)
             );
             response.status(HttpStatus.OK_200);
             return "";

--- a/src/main/java/com/artipie/front/settings/RepoSettings.java
+++ b/src/main/java/com/artipie/front/settings/RepoSettings.java
@@ -34,7 +34,7 @@ public final class RepoSettings {
     private final String layout;
 
     /**
-     * Repositories settings storage.
+     * Repositories configuration storage.
      */
     private final BlockingStorage repos;
 
@@ -158,6 +158,14 @@ public final class RepoSettings {
             res = String.format("%s/%s", uid, name);
         }
         return res;
+    }
+
+    /**
+     * Repositories configuration storage.
+     * @return Repo configs {@link BlockingStorage}
+     */
+    public BlockingStorage repoConfigsStorage() {
+        return this.repos;
     }
 
     /**

--- a/src/test/java/com/artipie/front/RepoITCase.java
+++ b/src/test/java/com/artipie/front/RepoITCase.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /**
  * Test for repository management APIs.
  * @since 0.1
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RepoITCase {
@@ -48,7 +49,7 @@ public final class RepoITCase {
     }
 
     @Test
-    void canManageRepos() {
+    void canManageRepos() throws InterruptedException {
         final String alice = this.client.token("Alice", "wonderland");
         MatcherAssert.assertThat(
             "Failed to obtain auth token for Alice", alice, new IsNot<>(Matchers.emptyString())
@@ -89,6 +90,7 @@ public final class RepoITCase {
             this.client.delete("/api/repositories/maven-repo", aladdin),
             new IsEqual<>(HttpStatus.OK_200)
         );
+        Thread.sleep(3000);
         MatcherAssert.assertThat(
             "Alice failed to check maven-repo exists",
             this.client.head("/api/repositories/maven-repo", alice),

--- a/src/test/java/com/artipie/front/RepoITCase.java
+++ b/src/test/java/com/artipie/front/RepoITCase.java
@@ -16,9 +16,8 @@ import org.hamcrest.core.IsNot;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -27,7 +26,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-@DisabledOnOs(OS.WINDOWS)
+@Disabled
 public final class RepoITCase {
 
     /**

--- a/src/test/java/com/artipie/front/RepoITCase.java
+++ b/src/test/java/com/artipie/front/RepoITCase.java
@@ -17,6 +17,8 @@ import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@DisabledOnOs(OS.WINDOWS)
 public final class RepoITCase {
 
     /**

--- a/src/test/java/com/artipie/front/RepoITCase.java
+++ b/src/test/java/com/artipie/front/RepoITCase.java
@@ -92,7 +92,6 @@ public final class RepoITCase {
             this.client.delete("/api/repositories/maven-repo", aladdin),
             new IsEqual<>(HttpStatus.OK_200)
         );
-        Thread.sleep(3000);
         MatcherAssert.assertThat(
             "Alice failed to check maven-repo exists",
             this.client.head("/api/repositories/maven-repo", alice),

--- a/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
@@ -73,7 +73,7 @@ class RepositoriesDeleteTest {
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(uid);
         MatcherAssert.assertThat(
             "Failed to process request",
-            new Repositories.Delete(stn, new RepoData(stn, this.blsto))
+            new Repositories.Delete(stn, new RepoData(stn))
                 .handle(rqs, Mockito.mock(Response.class)),
             new IsAnything<>()
         );

--- a/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
@@ -4,15 +4,22 @@
  */
 package com.artipie.front.api;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.front.RequestAttr;
+import com.artipie.front.settings.RepoData;
 import com.artipie.front.settings.RepoSettings;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
@@ -22,17 +29,32 @@ import spark.Response;
 /**
  * Test for {@link Repositories.Delete}.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 class RepositoriesDeleteTest {
+
+    /**
+     * Temp dir.
+     * @checkstyle VisibilityModifierCheck (500 lines)
+     */
+    @TempDir
+    Path temp;
 
     /**
      * Test storage.
      */
     private BlockingStorage blsto;
 
+    /**
+     * Data storage.
+     */
+    private Storage asto;
+
     @BeforeEach
     void init() {
         this.blsto = new BlockingStorage(new InMemoryStorage());
+        this.asto = new FileStorage(this.temp);
     }
 
     @ParameterizedTest
@@ -40,22 +62,41 @@ class RepositoriesDeleteTest {
         "flat,binary-repo.yaml,binary-repo",
         "org,Alice/docker.yml,docker"
     })
-    void removesRepository(final String layout, final String key, final String name) {
+    void removesRepository(final String layout, final String key, final String name)
+        throws InterruptedException {
         final String uid = "Alice";
-        this.blsto.save(new Key.From(key), new byte[]{});
+        final RepoSettings stn = new RepoSettings(layout, this.blsto);
+        this.blsto.save(new Key.From(key), this.repoSettings().getBytes(StandardCharsets.UTF_8));
+        this.asto.save(new Key.From(stn.name(name, uid), "data"), Content.EMPTY).join();
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(uid);
         MatcherAssert.assertThat(
             "Failed to process request",
-            new Repositories.Delete(new RepoSettings(layout, this.blsto))
+            new Repositories.Delete(stn, new RepoData(stn, this.blsto))
                 .handle(rqs, Mockito.mock(Response.class)),
             new IsAnything<>()
         );
+        Thread.sleep(3000);
         MatcherAssert.assertThat(
-            "Item was not removed from storage",
+            "Settings item was not removed from storage",
             this.blsto.exists(new Key.From(key)),
             new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Data item was not removed from storage",
+            this.asto.list(Key.ROOT).join().isEmpty()
+        );
+    }
+
+    private String repoSettings() {
+        return String.join(
+            System.lineSeparator(),
+            "repo:",
+            "  type: rpm",
+            "  storage:",
+            "    type: fs",
+            String.format("    path: %s", this.temp.toString())
         );
     }
 

--- a/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesDeleteTest.java
@@ -16,8 +16,9 @@ import com.artipie.front.settings.RepoSettings;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,7 +76,7 @@ class RepositoriesDeleteTest {
             "Failed to process request",
             new Repositories.Delete(stn, new RepoData(stn))
                 .handle(rqs, Mockito.mock(Response.class)),
-            new IsAnything<>()
+            new IsNot<>(new IsNull<>())
         );
         Thread.sleep(3000);
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
@@ -4,18 +4,26 @@
  */
 package com.artipie.front.api;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.front.RequestAttr;
+import com.artipie.front.settings.RepoData;
 import com.artipie.front.settings.RepoSettings;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import spark.Request;
 import spark.Response;
@@ -24,56 +32,67 @@ import spark.Response;
  * Test for {@link Repositories.Move}.
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class RepositoriesMoveTest {
 
     /**
-     * Test repository settings.
+     * Temp dir.
+     * @checkstyle VisibilityModifierCheck (500 lines)
      */
-    private static final String REPO = String.join(
-        System.lineSeparator(),
-        "repo:",
-        "  type: rpm",
-        "  storage:",
-        "    type: fs",
-        "    path: /var/artipie/data/"
-    );
+    @TempDir
+    Path temp;
 
     /**
      * Test storage.
      */
     private BlockingStorage blsto;
 
+    /**
+     * Data storage.
+     */
+    private Storage asto;
+
     @BeforeEach
     void init() {
         this.blsto = new BlockingStorage(new InMemoryStorage());
+        this.asto = new FileStorage(this.temp);
     }
 
     @Test
-    void movesRepo() {
+    void movesRepo() throws InterruptedException {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         final Key.From key = new Key.From("my-rpm.yml");
-        this.blsto.save(key, RepositoriesMoveTest.REPO.getBytes(StandardCharsets.UTF_8));
-        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-rpm");
+        this.blsto.save(key, this.repoSettings().getBytes(StandardCharsets.UTF_8));
+        final String name = "my-rpm";
+        this.asto.save(new Key.From(name, "data"), Content.EMPTY).join();
+        Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Mockito.when(rqs.body()).thenReturn("{ \"new_name\": \"alice-rpm\"}");
+        final RepoSettings stn = new RepoSettings("flat", this.blsto);
         MatcherAssert.assertThat(
             "Failed to return empty response",
-            new Repositories.Move(new RepoSettings("flat", this.blsto)).handle(rqs, resp),
+            new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp),
             new IsAnything<>()
         );
         Mockito.verify(resp).status(HttpStatus.OK_200);
+        Thread.sleep(3000);
         MatcherAssert.assertThat(
             "Failed to read repository settings",
             new String(this.blsto.value(new Key.From("alice-rpm.yml")), StandardCharsets.UTF_8),
-            new IsEqual<>(RepositoriesMoveTest.REPO)
+            new IsEqual<>(this.repoSettings())
         );
         MatcherAssert.assertThat(
             "Repo with old name should not exist",
             this.blsto.exists(key),
             new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Data were moved",
+            this.asto.list(Key.ROOT).join().stream().map(Key::string).collect(Collectors.toList()),
+            Matchers.contains("alice-rpm/data")
         );
     }
 
@@ -84,7 +103,8 @@ class RepositoriesMoveTest {
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-maven");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Mockito.when(rqs.body()).thenReturn("{ }");
-        new Repositories.Move(new RepoSettings("org", this.blsto)).handle(rqs, resp);
+        final RepoSettings stn = new RepoSettings("org", this.blsto);
+        new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
     }
 
@@ -95,8 +115,20 @@ class RepositoriesMoveTest {
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-docker");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(jane);
-        new Repositories.Move(new RepoSettings("org", this.blsto)).handle(rqs, resp);
+        final RepoSettings stn = new RepoSettings("org", this.blsto);
+        new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
+    }
+
+    private String repoSettings() {
+        return String.join(
+            System.lineSeparator(),
+            "repo:",
+            "  type: rpm",
+            "  storage:",
+            "    type: fs",
+            String.format("    path: %s", this.temp.toString())
+        );
     }
 
 }

--- a/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
@@ -19,8 +19,9 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -75,7 +76,7 @@ class RepositoriesMoveTest {
         MatcherAssert.assertThat(
             "Failed to return empty response",
             new Repositories.Move(stn, new RepoData(stn)).handle(rqs, resp),
-            new IsAnything<>()
+            new IsNot<>(new IsNull<>())
         );
         Mockito.verify(resp).status(HttpStatus.OK_200);
         Thread.sleep(3000);

--- a/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
+++ b/src/test/java/com/artipie/front/api/RepositoriesMoveTest.java
@@ -74,7 +74,7 @@ class RepositoriesMoveTest {
         final RepoSettings stn = new RepoSettings("flat", this.blsto);
         MatcherAssert.assertThat(
             "Failed to return empty response",
-            new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp),
+            new Repositories.Move(stn, new RepoData(stn)).handle(rqs, resp),
             new IsAnything<>()
         );
         Mockito.verify(resp).status(HttpStatus.OK_200);
@@ -104,7 +104,7 @@ class RepositoriesMoveTest {
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn("any");
         Mockito.when(rqs.body()).thenReturn("{ }");
         final RepoSettings stn = new RepoSettings("org", this.blsto);
-        new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp);
+        new Repositories.Move(stn, new RepoData(stn)).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
     }
 
@@ -116,7 +116,7 @@ class RepositoriesMoveTest {
         Mockito.when(rqs.params(Repositories.REPO_PARAM.toString())).thenReturn("my-docker");
         Mockito.when(rqs.attribute(RequestAttr.Standard.USER_ID.attrName())).thenReturn(jane);
         final RepoSettings stn = new RepoSettings("org", this.blsto);
-        new Repositories.Move(stn, new RepoData(stn, this.blsto)).handle(rqs, resp);
+        new Repositories.Move(stn, new RepoData(stn)).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
     }
 

--- a/src/test/java/com/artipie/front/settings/RepoDataTest.java
+++ b/src/test/java/com/artipie/front/settings/RepoDataTest.java
@@ -16,6 +16,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test for {@link RepoData}.
@@ -50,18 +52,18 @@ class RepoDataTest {
     void init() {
         this.stngs = new BlockingStorage(new InMemoryStorage());
         this.data = new BlockingStorage(new FileStorage(this.temp));
-        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
-        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
-        this.stngs.save(
-            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
-            this.repoSettings().getBytes(StandardCharsets.UTF_8)
-        );
     }
 
     @Test
     void removesData() {
-        new RepoData(new RepoSettings("flat", this.stngs)).remove(RepoDataTest.REPO, "any")
-            .toCompletableFuture().join();
+        this.stngs.save(
+            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettings().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
+        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+            .remove(RepoDataTest.REPO, "any").toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are removed",
             this.data.list(Key.ROOT).isEmpty()
@@ -70,14 +72,118 @@ class RepoDataTest {
 
     @Test
     void movesData() {
+        this.stngs.save(
+            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettings().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
         final String nrepo = "new-repo";
-        new RepoData(new RepoSettings("flat", this.stngs)).move(RepoDataTest.REPO, "any", nrepo)
-            .toCompletableFuture().join();
+        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+            .move(RepoDataTest.REPO, "any", nrepo).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are moved",
             this.data.list(Key.ROOT).stream().map(Key::string)
                 .collect(Collectors.toList()),
             Matchers.contains("new-repo/first.txt", "new-repo/second.txt")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"_storage.yaml", "_storage.yml", "my-repo/_storage.yaml", "my-repo/_storage.yml"}
+    )
+    void movesDataWithAliasAndFlatLayout(final String key) {
+        this.stngs.save(
+            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettingsWithAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.stngs.save(
+            new Key.From(key),
+            this.storageAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
+        final String nrepo = "new-repo";
+        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+            .move(RepoDataTest.REPO, "any", nrepo).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository data are moved",
+            this.data.list(Key.ROOT).stream().map(Key::string).collect(Collectors.toList()),
+            Matchers.contains("new-repo/first.txt", "new-repo/second.txt")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"_storage.yaml", "_storage.yml", "my-repo/_storage.yaml", "my-repo/_storage.yml"}
+    )
+    void movesDataWithAliasAndOrgLayout(final String key) {
+        final String uid = "john";
+        this.stngs.save(
+            new Key.From(uid, String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettingsWithAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.stngs.save(
+            new Key.From(uid, key),
+            this.storageAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(uid, RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(uid, RepoDataTest.REPO, "second.txt"), new byte[]{});
+        final String nrepo = "new-repo";
+        new RepoData(new RepoSettings("org", this.stngs), this.stngs)
+            .move(RepoDataTest.REPO, uid, nrepo).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository data are moved",
+            this.data.list(Key.ROOT).stream().map(Key::string).collect(Collectors.toList()),
+            Matchers.contains("john/new-repo/first.txt", "john/new-repo/second.txt")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"_storage.yaml", "_storage.yml", "my-repo/_storage.yaml", "my-repo/_storage.yml"}
+    )
+    void removesDataWithAliasAndFlatLayout(final String key) {
+        this.stngs.save(
+            new Key.From(String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettingsWithAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.stngs.save(
+            new Key.From(key),
+            this.storageAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
+        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+            .remove(RepoDataTest.REPO, "any").toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository data are moved",
+            this.data.list(Key.ROOT).isEmpty()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"_storage.yaml", "_storage.yml", "my-repo/_storage.yaml", "my-repo/_storage.yml"}
+    )
+    void removesDataWithAliasAndOrgLayout(final String key) {
+        final String uid = "john";
+        this.stngs.save(
+            new Key.From(uid, String.format("%s.yml", RepoDataTest.REPO)),
+            this.repoSettingsWithAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.stngs.save(
+            new Key.From(uid, key),
+            this.storageAlias().getBytes(StandardCharsets.UTF_8)
+        );
+        this.data.save(new Key.From(uid, RepoDataTest.REPO, "first.txt"), new byte[]{});
+        this.data.save(new Key.From(uid, RepoDataTest.REPO, "second.txt"), new byte[]{});
+        new RepoData(new RepoSettings("org", this.stngs), this.stngs)
+            .remove(RepoDataTest.REPO, uid).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Repository is empty",
+            this.data.list(Key.ROOT).isEmpty()
         );
     }
 
@@ -87,6 +193,28 @@ class RepoDataTest {
             "repo:",
             "  type: binary",
             "  storage:",
+            "    type: fs",
+            String.format("    path: %s", this.temp.toString())
+        );
+    }
+
+    private String repoSettingsWithAlias() {
+        return String.join(
+            System.lineSeparator(),
+            "repo:",
+            "  type: binary",
+            "  storage: local"
+        );
+    }
+
+    private String storageAlias() {
+        return String.join(
+            System.lineSeparator(),
+            "storages:",
+            "  default:",
+            "    type: fs",
+            "    path: /usr/def",
+            "  local:",
             "    type: fs",
             String.format("    path: %s", this.temp.toString())
         );

--- a/src/test/java/com/artipie/front/settings/RepoDataTest.java
+++ b/src/test/java/com/artipie/front/settings/RepoDataTest.java
@@ -62,7 +62,7 @@ class RepoDataTest {
         );
         this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
-        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("flat", this.stngs))
             .remove(RepoDataTest.REPO, "any").toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are removed",
@@ -79,7 +79,7 @@ class RepoDataTest {
         this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
         final String nrepo = "new-repo";
-        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("flat", this.stngs))
             .move(RepoDataTest.REPO, "any", nrepo).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are moved",
@@ -105,7 +105,7 @@ class RepoDataTest {
         this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
         final String nrepo = "new-repo";
-        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("flat", this.stngs))
             .move(RepoDataTest.REPO, "any", nrepo).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are moved",
@@ -131,7 +131,7 @@ class RepoDataTest {
         this.data.save(new Key.From(uid, RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(uid, RepoDataTest.REPO, "second.txt"), new byte[]{});
         final String nrepo = "new-repo";
-        new RepoData(new RepoSettings("org", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("org", this.stngs))
             .move(RepoDataTest.REPO, uid, nrepo).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are moved",
@@ -155,7 +155,7 @@ class RepoDataTest {
         );
         this.data.save(new Key.From(RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(RepoDataTest.REPO, "second.txt"), new byte[]{});
-        new RepoData(new RepoSettings("flat", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("flat", this.stngs))
             .remove(RepoDataTest.REPO, "any").toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository data are moved",
@@ -179,7 +179,7 @@ class RepoDataTest {
         );
         this.data.save(new Key.From(uid, RepoDataTest.REPO, "first.txt"), new byte[]{});
         this.data.save(new Key.From(uid, RepoDataTest.REPO, "second.txt"), new byte[]{});
-        new RepoData(new RepoSettings("org", this.stngs), this.stngs)
+        new RepoData(new RepoSettings("org", this.stngs))
             .remove(RepoDataTest.REPO, uid).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Repository is empty",


### PR DESCRIPTION
Part of https://github.com/artipie/artipie/issues/923 

Fully implemented moving data on storage rename and removing data on storage remove. (Re)move data operations are performed asynchronously and we do not wait for process to complete before returning a response.  