### PR TITLE
feat: support auth from env

### DIFF
--- a/src/main/java/com/artipie/front/auth/Credentials.java
+++ b/src/main/java/com/artipie/front/auth/Credentials.java
@@ -4,6 +4,8 @@
  */
 package com.artipie.front.auth;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -17,5 +19,41 @@ public interface Credentials {
      * @return User if found
      */
     Optional<User> user(String name);
+
+    /**
+     * Decorator of {@link Credentials}, which tries to find user among several
+     * {@link Credentials} implementations, returns any user if found, empty optional
+     * if user not found.
+     * @since 0.2
+     */
+    class Any implements Credentials {
+
+        /**
+         * Origins list.
+         */
+        private final Collection<Credentials> creds;
+
+        /**
+         * Primary ctor.
+         * @param creds Origins
+         */
+        public Any(final Collection<Credentials> creds) {
+            this.creds = creds;
+        }
+
+        /**
+         * Ctor.
+         * @param creds Origins
+         */
+        public Any(final Credentials... creds) {
+            this(Arrays.asList(creds));
+        }
+
+        @Override
+        public Optional<User> user(final String name) {
+            return this.creds.stream().filter(item -> item.user(name).isPresent()).findFirst()
+                .flatMap(item -> item.user(name));
+        }
+    }
 
 }

--- a/src/main/java/com/artipie/front/auth/EnvCredentials.java
+++ b/src/main/java/com/artipie/front/auth/EnvCredentials.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Credentials from env.
+ * @since 0.2
+ */
+public final class EnvCredentials implements Credentials {
+
+    /**
+     * Environment name for user.
+     */
+    public static final String ENV_NAME = "ARTIPIE_USER_NAME";
+
+    /**
+     * Environment name for password.
+     */
+    private static final String ENV_PASS = "ARTIPIE_USER_PASS";
+
+    /**
+     * Environment variables.
+     */
+    private final Map<String, String> env;
+
+    /**
+     * Ctor.
+     * @param env Environment
+     */
+    public EnvCredentials(final Map<String, String> env) {
+        this.env = env;
+    }
+
+    /**
+     * Default ctor with system environment.
+     */
+    public EnvCredentials() {
+        this(System.getenv());
+    }
+
+    @Override
+    public Optional<User> user(final String name) {
+        Optional<User> result = Optional.empty();
+        if (Objects.equals(Objects.requireNonNull(name), this.env.get(EnvCredentials.ENV_NAME))
+            && this.env.get(EnvCredentials.ENV_PASS) != null) {
+            result = Optional.of(
+                // @checkstyle AnonInnerLengthCheck (30 lines)
+                new User() {
+                    @Override
+                    public boolean validatePassword(final String pass) {
+                        return Objects.equals(
+                            pass, EnvCredentials.this.env.get(EnvCredentials.ENV_PASS)
+                        );
+                    }
+
+                    @Override
+                    public String uid() {
+                        return name;
+                    }
+
+                    @Override
+                    public Set<? extends String> groups() {
+                        return Collections.emptySet();
+                    }
+
+                    @Override
+                    public Optional<String> email() {
+                        return Optional.empty();
+                    }
+                }
+            );
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/artipie/front/auth/CredentialsAnyTest.java
+++ b/src/test/java/com/artipie/front/auth/CredentialsAnyTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import java.util.Map;
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link Credentials.Any}.
+ * @since 0.2
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class CredentialsAnyTest {
+
+    @Test
+    void findsUser() {
+        final String alice = "Alice";
+        MatcherAssert.assertThat(
+            new Credentials.Any(
+                name -> Optional.empty(),
+                name -> Optional.empty(),
+                new EnvCredentials(Map.of("ARTIPIE_USER_NAME", alice, "ARTIPIE_USER_PASS", "any")),
+                name -> Optional.empty(),
+                new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Bob", "ARTIPIE_USER_PASS", "any"))
+            ).user(alice).get().uid(),
+            new IsEqual<>(alice)
+        );
+    }
+
+    @Test
+    void returnsEmptyIfNotFound() {
+        MatcherAssert.assertThat(
+            new Credentials.Any(
+                new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Jane", "ARTIPIE_USER_PASS", "any")),
+                name -> Optional.empty(),
+                new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Alex", "ARTIPIE_USER_PASS", "any"))
+            ).user("Artipie").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/front/auth/EnvCredentialsTest.java
+++ b/src/test/java/com/artipie/front/auth/EnvCredentialsTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2022 artipie.com
+ * https://github.com/artipie/front/LICENSE.txt
+ */
+package com.artipie.front.auth;
+
+import java.util.Collections;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link EnvCredentials}.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class EnvCredentialsTest {
+
+    @Test
+    void findsUser() {
+        final String alice = "Alice";
+        MatcherAssert.assertThat(
+            new EnvCredentials(
+                Map.of("ARTIPIE_USER_NAME", alice, "ARTIPIE_USER_PASS", "any")
+            ).user(alice).get().uid(),
+            new IsEqual<>(alice)
+        );
+    }
+
+    @Test
+    void doesNotFindUserWhenPasswordIsAbsent() {
+        final String bob = "Bob";
+        MatcherAssert.assertThat(
+            new EnvCredentials(
+                Map.of("ARTIPIE_USER_NAME", bob)
+            ).user(bob).isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void doesNotFindUserWhenMapIsEmpty() {
+        MatcherAssert.assertThat(
+            new EnvCredentials(Collections.emptyMap()).user("Artipie").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+}


### PR DESCRIPTION
Part of #79 
Added implementation of `Credentials` interface to obtain credentials from env and `Credentials.Any` decorator to find user in several credentials implementations.  