### PR TITLE
fix: do not add `github.com/` prefix

### DIFF
--- a/src/main/java/com/artipie/front/auth/AuthByPassword.java
+++ b/src/main/java/com/artipie/front/auth/AuthByPassword.java
@@ -30,6 +30,6 @@ public interface AuthByPassword {
     static AuthByPassword withCredentials(final Credentials cred) {
         return (name, pass) -> cred.user(name)
             .filter(user -> user.validatePassword(pass))
-            .map(ignore -> name);
+            .map(User::uid);
     }
 }

--- a/src/test/java/com/artipie/front/auth/GithubCredentialsTest.java
+++ b/src/test/java/com/artipie/front/auth/GithubCredentialsTest.java
@@ -37,16 +37,23 @@ class GithubCredentialsTest {
     @Test
     void resolveUserByToken() {
         final String secret = "secret";
-        MatcherAssert.assertThat(
-            new GithubCredentials(
-                // @checkstyle ReturnCountCheck (5 lines)
-                token -> {
-                    if (token.equals(secret)) {
-                        return "User";
-                    }
-                    return "";
+        final User user = new GithubCredentials(
+            // @checkstyle ReturnCountCheck (5 lines)
+            token -> {
+                if (token.equals(secret)) {
+                    return "User";
                 }
-            ).user("github.com/UsEr").orElseThrow().validatePassword(secret),
+                return "";
+            }
+        ).user("github.com/UsEr").orElseThrow();
+        MatcherAssert.assertThat(
+            "User uid should not contain `github.com/` prefix",
+            user.uid(),
+            new IsEqual<>("UsEr")
+        );
+        MatcherAssert.assertThat(
+            "Password is validated",
+            user.validatePassword(secret),
             new IsEqual<>(true)
         );
     }


### PR DESCRIPTION
Closes #58 
Extended test for `GithubCredentials` to make sure `github.com/` is removed from user name and fix `AuthByPassword#withCredentials` to obtain `uid` from `User` instance.