### PR TITLE
fix: extend login page

### DIFF
--- a/src/main/java/com/artipie/front/settings/ArtipieYaml.java
+++ b/src/main/java/com/artipie/front/settings/ArtipieYaml.java
@@ -100,9 +100,7 @@ public final class ArtipieYaml {
      */
     public Users users() {
         return new YamlUsers(
-            this.fileCredentialsKey().orElseThrow(
-                () -> new IllegalStateException("Only users from file auth are supported")
-            ), this.storage()
+            this.fileCredentialsKey().orElse(new Key.From("_credentials.yml")), this.storage()
         );
     }
 

--- a/src/main/resources/html/signin
+++ b/src/main/resources/html/signin
@@ -11,5 +11,10 @@
         <input name="submit" type="submit"/>
     </fieldset>
 </form>
+
+Use your GitHub account to login: username is <code>github.com/{username}</code>,
+password is GitHub <a href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">personal access token</a>.
+Or contact us in <a href="https://t.me/artipie">Telegram</a> and we create an account for you.
+
 {{/partial}}
 {{> base}}

--- a/src/main/resources/html/signin
+++ b/src/main/resources/html/signin
@@ -1,5 +1,10 @@
 {{#partial "content"}}
 
+Use your GitHub account to login: username is <code>github.com/{username}</code>,
+password is GitHub <a href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">personal access token</a>.
+Or contact us in <a href="https://t.me/artipie">Telegram</a> and we create an account for you.
+<br/>
+<br/>
 <form id="form-signin" method="post">
     <fieldset>
         <label for="username">User:</label>
@@ -11,10 +16,5 @@
         <input name="submit" type="submit"/>
     </fieldset>
 </form>
-
-Use your GitHub account to login: username is <code>github.com/{username}</code>,
-password is GitHub <a href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">personal access token</a>.
-Or contact us in <a href="https://t.me/artipie">Telegram</a> and we create an account for you.
-
 {{/partial}}
 {{> base}}


### PR DESCRIPTION
Part of https://github.com/artipie/artipie/issues/1058
<img width="500" alt="image" src="https://user-images.githubusercontent.com/14931449/179954769-b3015cf9-8548-4d16-97e5-3f256f163d6f.png">

added info about how to login via github and link to our tlg group
Also, fixed `com.artipie.front.settings.ArtipieYaml#users` to use default credentials file name in the case when it's not set manually, `YamlUsers` class takes responsibility to check existence of the file and acts accordingly.