### PR TITLE
feat: reload credentials on update

### DIFF
--- a/src/main/java/com/artipie/front/api/Users.java
+++ b/src/main/java/com/artipie/front/api/Users.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.front.api;
 
+import com.artipie.front.auth.Credentials;
 import com.artipie.front.auth.User;
 import com.artipie.front.misc.RequestPath;
 import java.io.StringReader;
@@ -139,16 +140,24 @@ public final class Users {
         private final com.artipie.front.auth.Users users;
 
         /**
+         * Front service credentials.
+         */
+        private final Credentials creds;
+
+        /**
          * Ctor.
          * @param users Artipie users
+         * @param creds Front service credentials
          */
-        public Delete(final com.artipie.front.auth.Users users) {
+        public Delete(final com.artipie.front.auth.Users users, final Credentials creds) {
             this.users = users;
+            this.creds = creds;
         }
 
         @Override
         public Object handle(final Request request, final Response response) {
             this.users.remove(USER_PARAM.parse(request));
+            this.creds.reload();
             response.status(HttpStatus.OK_200);
             return "";
         }
@@ -203,11 +212,18 @@ public final class Users {
         private final com.artipie.front.auth.Users users;
 
         /**
+         * Front service credentials.
+         */
+        private final Credentials creds;
+
+        /**
          * Ctor.
          * @param users Artipie users
+         * @param creds Front service credentials
          */
-        public Put(final com.artipie.front.auth.Users users) {
+        public Put(final com.artipie.front.auth.Users users, final Credentials creds) {
             this.users = users;
+            this.creds = creds;
         }
 
         @Override
@@ -233,6 +249,7 @@ public final class Users {
                 return "Password field `pass` is required";
             }
             this.users.add(user, name);
+            this.creds.reload();
             response.status(HttpStatus.CREATED_201);
             return "";
         }

--- a/src/main/java/com/artipie/front/auth/Credentials.java
+++ b/src/main/java/com/artipie/front/auth/Credentials.java
@@ -21,6 +21,12 @@ public interface Credentials {
     Optional<User> user(String name);
 
     /**
+     * Reload or re-read credentials. Depending on implementation, this
+     * method can do nothing.
+     */
+    void reload();
+
+    /**
      * Decorator of {@link Credentials}, which tries to find user among several
      * {@link Credentials} implementations, returns any user if found, empty optional
      * if user not found.
@@ -53,6 +59,11 @@ public interface Credentials {
         public Optional<User> user(final String name) {
             return this.creds.stream().filter(item -> item.user(name).isPresent()).findFirst()
                 .flatMap(item -> item.user(name));
+        }
+
+        @Override
+        public void reload() {
+            this.creds.forEach(Credentials::reload);
         }
     }
 

--- a/src/main/java/com/artipie/front/auth/EnvCredentials.java
+++ b/src/main/java/com/artipie/front/auth/EnvCredentials.java
@@ -87,4 +87,9 @@ public final class EnvCredentials implements Credentials {
         }
         return result;
     }
+
+    @Override
+    public void reload() {
+        // does nothing
+    }
 }

--- a/src/main/java/com/artipie/front/auth/GithubCredentials.java
+++ b/src/main/java/com/artipie/front/auth/GithubCredentials.java
@@ -71,6 +71,11 @@ public final class GithubCredentials implements Credentials {
     }
 
     @Override
+    public void reload() {
+        // does nothing
+    }
+
+    @Override
     public String toString() {
         return String.format("%s()", this.getClass().getSimpleName());
     }

--- a/src/main/java/com/artipie/front/auth/YamlCredentials.java
+++ b/src/main/java/com/artipie/front/auth/YamlCredentials.java
@@ -93,6 +93,11 @@ public final class YamlCredentials implements Credentials {
             .map(yaml -> new YamlUser(yaml, name));
     }
 
+    @Override
+    public void reload() {
+        this.creds.invalidateAll();
+    }
+
     /**
      * Yaml user item.
      * @since 1.0

--- a/src/test/java/com/artipie/front/api/UsersDeleteTest.java
+++ b/src/test/java/com/artipie/front/api/UsersDeleteTest.java
@@ -7,11 +7,14 @@ package com.artipie.front.api;
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.front.auth.Credentials;
+import com.artipie.front.auth.User;
 import com.artipie.front.auth.Users;
 import com.artipie.front.auth.YamlCredentialsTest;
 import com.artipie.front.auth.YamlUsers;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -24,6 +27,7 @@ import spark.Response;
 /**
  * Test for {@link com.artipie.front.api.Users.Delete}.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (100 lines)
  */
 class UsersDeleteTest {
 
@@ -63,12 +67,49 @@ class UsersDeleteTest {
         Mockito.when(rqs.params(com.artipie.front.api.Users.USER_PARAM.toString()))
             .thenReturn(alice);
         final Response resp = Mockito.mock(Response.class);
-        new com.artipie.front.api.Users.Delete(this.users).handle(rqs, resp);
+        final FakeCreds creds = new FakeCreds();
+        new com.artipie.front.api.Users.Delete(this.users, creds).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.OK_200);
         MatcherAssert.assertThat(
+            "One user was added",
             this.users.list().size(),
             new IsEqual<>(1)
         );
+        MatcherAssert.assertThat(
+            "Creds were reloaded",
+            creds.wasReloaded(),
+            new IsEqual<>(true)
+        );
+    }
+
+    /**
+     * Fake credentials for test.
+     * @since 0.1
+     */
+    static class FakeCreds implements Credentials {
+
+        /**
+         * Reload operation counter.
+         */
+        private final AtomicInteger reloaded = new AtomicInteger(0);
+
+        @Override
+        public Optional<User> user(final String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void reload() {
+            this.reloaded.incrementAndGet();
+        }
+
+        /**
+         * Were creds reloaded?
+         * @return True if credentials were reloaded
+         */
+        public boolean wasReloaded() {
+            return this.reloaded.get() == 1;
+        }
     }
 
 }

--- a/src/test/java/com/artipie/front/api/UsersPutTest.java
+++ b/src/test/java/com/artipie/front/api/UsersPutTest.java
@@ -26,6 +26,7 @@ import spark.Response;
 /**
  * Test for {@link Users.Put}.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (100 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class UsersPutTest {
@@ -66,9 +67,11 @@ class UsersPutTest {
         final var name = "john";
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.body()).thenReturn(this.rqBody(name));
-        new Users.Put(this.users).handle(rqs, resp);
+        final UsersDeleteTest.FakeCreds creds = new UsersDeleteTest.FakeCreds();
+        new Users.Put(this.users, creds).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CREATED_201);
         MatcherAssert.assertThat(
+            "Added user",
             new String(
                 this.asto.value(new Key.From(UsersPutTest.CREDS_YAML)), StandardCharsets.UTF_8
             ),
@@ -92,6 +95,11 @@ class UsersPutTest {
                 )
             )
         );
+        MatcherAssert.assertThat(
+            "Creds were reloaded",
+            creds.wasReloaded(),
+            new IsEqual<>(true)
+        );
     }
 
     @Test
@@ -101,7 +109,8 @@ class UsersPutTest {
         final var name = "Alice";
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(name);
         Mockito.when(rqs.body()).thenReturn(this.rqBody(name));
-        new Users.Put(this.users).handle(rqs, resp);
+        final UsersDeleteTest.FakeCreds creds = new UsersDeleteTest.FakeCreds();
+        new Users.Put(this.users, creds).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CREATED_201);
         MatcherAssert.assertThat(
             new String(
@@ -121,6 +130,11 @@ class UsersPutTest {
                 )
             )
         );
+        MatcherAssert.assertThat(
+            "Creds were reloaded",
+            creds.wasReloaded(),
+            new IsEqual<>(true)
+        );
     }
 
     @ParameterizedTest
@@ -130,8 +144,14 @@ class UsersPutTest {
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn("Alice");
         Mockito.when(rqs.body()).thenReturn(body);
-        new Users.Put(this.users).handle(rqs, resp);
+        final UsersDeleteTest.FakeCreds creds = new UsersDeleteTest.FakeCreds();
+        new Users.Put(this.users, creds).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.BAD_REQUEST_400);
+        MatcherAssert.assertThat(
+            "Creds were not reloaded",
+            creds.wasReloaded(),
+            new IsEqual<>(false)
+        );
     }
 
     @Test
@@ -147,8 +167,14 @@ class UsersPutTest {
         final var resp = Mockito.mock(Response.class);
         final var rqs = Mockito.mock(Request.class);
         Mockito.when(rqs.params(Users.USER_PARAM.toString())).thenReturn(name);
-        new Users.Put(this.users).handle(rqs, resp);
+        final UsersDeleteTest.FakeCreds creds = new UsersDeleteTest.FakeCreds();
+        new Users.Put(this.users, creds).handle(rqs, resp);
         Mockito.verify(resp).status(HttpStatus.CONFLICT_409);
+        MatcherAssert.assertThat(
+            "Creds were not reloaded",
+            creds.wasReloaded(),
+            new IsEqual<>(false)
+        );
     }
 
     /**

--- a/src/test/java/com/artipie/front/auth/CredentialsAnyTest.java
+++ b/src/test/java/com/artipie/front/auth/CredentialsAnyTest.java
@@ -22,10 +22,10 @@ class CredentialsAnyTest {
         final String alice = "Alice";
         MatcherAssert.assertThat(
             new Credentials.Any(
-                name -> Optional.empty(),
-                name -> Optional.empty(),
+                new FakeCreds(),
+                new FakeCreds(),
                 new EnvCredentials(Map.of("ARTIPIE_USER_NAME", alice, "ARTIPIE_USER_PASS", "any")),
-                name -> Optional.empty(),
+                new FakeCreds(),
                 new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Bob", "ARTIPIE_USER_PASS", "any"))
             ).user(alice).get().uid(),
             new IsEqual<>(alice)
@@ -37,11 +37,28 @@ class CredentialsAnyTest {
         MatcherAssert.assertThat(
             new Credentials.Any(
                 new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Jane", "ARTIPIE_USER_PASS", "any")),
-                name -> Optional.empty(),
+                new FakeCreds(),
                 new EnvCredentials(Map.of("ARTIPIE_USER_NAME", "Alex", "ARTIPIE_USER_PASS", "any"))
             ).user("Artipie").isEmpty(),
             new IsEqual<>(true)
         );
+    }
+
+    /**
+     * Fake credentials for test.
+     * @since 0.1
+     */
+    private static class FakeCreds implements Credentials {
+
+        @Override
+        public Optional<User> user(final  String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void reload() {
+            //does nothing
+        }
     }
 
 }


### PR DESCRIPTION
Closes #91 
Added methods to reload yaml credentials when users are updated/deleted via API methods.